### PR TITLE
close #40 makeに失敗するため、std::coutをprintfに変更

### DIFF
--- a/module/CourseInfo.cpp
+++ b/module/CourseInfo.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "CourseInfo.h"
-using std::string;
 
 // 目標とする輝度と、各区間の名前と距離を設定する
 CourseInfo::CourseInfo(int _brightness)
@@ -14,8 +13,8 @@ CourseInfo::CourseInfo(int _brightness)
 {
   // 入力値が輝度の取りうる範囲外だった場合、エラーメッセージを出力
   if(_brightness < 0 || 100 < _brightness) {
-    std::cout << "CourseInfo:期待しない値(" << _brightness << ")が入力されました。目標とする輝度を"
-              << targetBrightness << "に設定します。\n";
+    printf("CourseInfo:期待しない値(%d)が入力されました。目標とする輝度を%dに設定します。\n",
+           _brightness, targetBrightness);
   }
 }
 

--- a/module/CourseInfo.h
+++ b/module/CourseInfo.h
@@ -7,7 +7,7 @@
 #ifndef COURSE_INFO_H
 #define COURSE_INFO_H
 
-#include <iostream>
+#include <stdio.h>
 
 /**
  * コース情報を保持するクラス


### PR DESCRIPTION
# チェックリスト
- [x] clang-formatしている
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている
# 変更点
- iostreamをincludeするとmakeに失敗するため、`std::cout` を `printf` に変更した
- MileageクラスをMakefile.incから除外した場合に、make, gtest_allがパスすることを確認した (※Mileageクラスの修正は別チケット)
- このプルリクでは、Makefile.incは変更しない