### PR TITLE
close #37 Makefile.inc ファイルを編集しないで済むようになった

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,14 +2,10 @@ mkfile_path := $(dir $(lastword $(MAKEFILE_LIST)))
 
 APPL_COBJS +=
 
-# ここに追加したクラスを追加する
-APPL_CXXOBJS += \
-    EtRobocon2021.o \
-    Controller.o \
-    Measurer.o \
-    Pid.o \
-    CourseInfo.o \
-    Mileage.o \
+# moduleディレクトリ中に追加したクラスを検索する
+APPL_CXXOBJS += $(shell echo \
+                    `ls ${HOME}/etrobo/workspace/etrobocon2021/module/*.cpp | \
+                     sed -r 's/(\/.*)*\/(.*\.)cpp/\2o/g'`)
 
 SRCLANG := c++
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -25,6 +25,7 @@ INCLUDES += \
     -I$(mkfile_path)app \
     -I$(mkfile_path)module \
     -I$(mkfile_path)module/api \
+    -I$(ETROBO_HRP3_WORKSPACE)/etroboc_common \
 
 COPTS += -std=gnu++11
 


### PR DESCRIPTION
# チェックリスト
- [X] clang-formatしている
- [X] コーディング規約に準じている
- [X] チケットの完了条件を満たしている

# 変更点
- Makefile.inc ファイルの `APPL_CXXOBJS` を手動で更新しないで済むようにした
- Makefile.inc ファイルの `INCLUDES` に `-I$(ETROBO_HRP3_WORKSPACE)/etroboc_common` を追記

## 参考
- [sim_extended_api · ETrobocon/etrobo Wiki](https://github.com/ETrobocon/etrobo/wiki/sim_extended_api)

## 動作確認の際のログ

```bash
$ git log
commit 9fdc35e32615f3bbe9d8b827bd3e0ec7f66ff78a (HEAD -> ticket-37)
Merge: 19c6a52 041a614
Author: Takahiro55555 <tkhr.corei7@gmail.com>
Date:   Sat Jun 5 04:45:47 2021 +0900

    Merge remote-tracking branch 'origin/ticket-38' into ticket-37

commit 19c6a52d2112b376755029ced704153014732578
Merge: c2e8fe3 63ccedc
Author: Takahiro55555 <tkhr.corei7@gmail.com>
Date:   Sat Jun 5 04:45:40 2021 +0900

    Merge remote-tracking branch 'origin/ticket-40' into ticket-37

commit c2e8fe3099da3ed7806d7de440dd560fe5d83192 (origin/ticket-37)
Author: Takahiro55555 <tkhr.corei7@gmail.com>
Date:   Sat Jun 5 04:44:44 2021 +0900

    update: シミュレータ用拡張APIを使えるようにした
```


```bash
$ make app=etrobocon2021
invoke: make app=etrobocon2021
rm -rf /home/tkhr/etrobo/hrp3/sdk/workspace/.././OBJ/
/usr/lib/ruby/2.5.0/shell.rb:147: warning: Insecure world writable dir /mnt/c in PATH, mode 040777
Generating Makefile from ../common/Makefile.app.
make[1]: Entering directory '/home/tkhr/etrobo/hrp3/sdk/OBJ'
rm -f cfg1_out cfg1_out.o cfg1_out.c cfg1_out.syms cfg1_out.srec module_cfg.h module_cfg.c \#* *~ *.o
make[1]: Leaving directory '/home/tkhr/etrobo/hrp3/sdk/OBJ'
make[1]: Entering directory '/home/tkhr/etrobo/hrp3/sdk/OBJ'
  CFG[1]  module_cfg.h
[cfg.rb] Generated cfg1_out.c
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CFG[2]  module_cfg.h
[cfg.rb] Generated module_cfg.c
[cfg.rb] Generated module_cfg.h
make[1]: Leaving directory '/home/tkhr/etrobo/hrp3/sdk/OBJ'
make[1]: Entering directory '/home/tkhr/etrobo/hrp3/sdk/OBJ'
  CC      module_cfg.c
  CC      ../../library/t_perror.c
  CC      ../../library/strerror.c
  CC      ../../target/ev3_gcc/TLSF-2.4.6/src/tlsf.c
  CC      ../../library/vasyslog.c
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CC      ../common/ev3api/src/ev3api.c
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CC      ../common/ev3api/src/ev3api_battery.c
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CC      ../common/ev3api/src/ev3api_brick.c
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CC      ../common/ev3api/src/ev3api_fs.c
  CC      ../common/ev3api/src/ev3api_speaker.c
  CC      ../common/ev3api/src/ev3api_lcd.c
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CC      ../common/ev3api/src/ev3api_motor.c
  CC      ../common/ev3api/src/ev3api_newlib.c
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CC      ../common/ev3api/src/ev3api_sensor.c
  CXX     ../workspace/etrobocon2021/module/Controller.cpp
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CXX     ../workspace/etrobocon2021/module/CourseInfo.cpp
cc1: warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C
  CXX     ../workspace/etrobocon2021/module/EtRobocon2021.cpp
  CXX     ../workspace/etrobocon2021/module/Measurer.cpp
  CXX     ../workspace/etrobocon2021/module/Mileage.cpp
  CXX     ../workspace/etrobocon2021/module/Pid.cpp
  CXX     ../workspace/etrobocon2021/app.cpp
In file included from ../workspace/etrobocon2021/module/Pid.cpp:7:0:
../workspace/etrobocon2021/module/Pid.h: In constructor 'Pid::Pid(double, double, double, double)':
../workspace/etrobocon2021/module/Pid.h:56:10: warning: 'Pid::integral' will be initialized after [-Wreorder]
   double integral;      //偏差の累積
          ^~~~~~~~
../workspace/etrobocon2021/module/Pid.h:55:10: warning:   'double Pid::preDeviation' [-Wreorder]
   double preDeviation;  //前回の偏差
          ^~~~~~~~~~~~
../workspace/etrobocon2021/module/Pid.cpp:11:1: warning:   when initialized here [-Wreorder]
 Pid::Pid(double _kp, double _ki, double _kd, double _targetValue)
 ^~~
  LD      app
make[1]: Leaving directory '/home/tkhr/etrobo/hrp3/sdk/OBJ'
fakemake on HRP3: build succeed: etrobocon2021
```