### PR TITLE
close #43 etrobo環境でのビルド確認をするようにした

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -36,7 +36,7 @@ jobs:
           echo TAG=$TAG >> $GITHUB_ENV
 
       - name: Build and publish docker image
-        if: ${{ env.IS_REBUILD_DOCKER_IMAGE == 'true' }}
+        if: ${{ env.IS_REBUILD_DOCKER_IMAGE == 'false' }}
         uses: matootie/github-docker@v3.1.0
         with:
           accessToken: ${{ secrets.PAT }}

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -36,7 +36,7 @@ jobs:
           echo TAG=$TAG >> $GITHUB_ENV
 
       - name: Build and publish docker image
-        if: ${{ env.IS_REBUILD_DOCKER_IMAGE == 'false' }}
+        if: ${{ env.IS_REBUILD_DOCKER_IMAGE == 'true' }}
         uses: matootie/github-docker@v3.1.0
         with:
           accessToken: ${{ secrets.PAT }}
@@ -49,5 +49,5 @@ jobs:
       - name: ETRobocon build test
         run: |
           echo ${{ secrets.PAT }} | docker login ghcr.io -u Takahiro55555 --password-stdin
-          docker pull ghcr.io/takahiro55555/github-actions-etrobocon2021
-          docker run -v ${{ github.workspace }}:/tmp/etrobocon2021:rw ghcr.io/takahiro55555/github-actions-etrobocon2021
+          docker pull ghcr.io/katlab-miyazakiuniv/github-actions-etrobocon2021
+          docker run -v ${{ github.workspace }}:/tmp/etrobocon2021:rw ghcr.io/katlab-miyazakiuniv/github-actions-etrobocon2021

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -8,9 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+
+      # ${{ github.workspace }} を使用するために必要
       - name: checkout
         uses: actions/checkout@v1
 
+      # https://github.com/ETrobocon/etrobo/ の master ブランチの最新のコミットIDと、
+      # Dockerfile と entrypoint.sh を結合したファイルのハッシュ値を結合して、
+      # Docker image のタグを生成する。
+      #     GitHub API Doc: https://docs.github.com/ja/rest/reference/repos#list-organization-repositories
       - name: Create docker image tag
         run: |
           cat ${{ github.workspace }}/Dockerfile > /tmp/update-check.txt
@@ -22,37 +28,41 @@ jobs:
             sed -e 's/"//g'`
           TAG=${TAG}.`md5sum /tmp/update-check.txt | cut -d ' ' -f 1`
           echo TAG=$TAG >> $GITHUB_ENV
-      
+
+      # 上記で生成したタグが GitHub Container Registry に存在するかを確認する
+      # 存在しない場合、新たに Docker image をビルドするためのフラグ(IS_REBUILD_DOCKER_IMAGE)を立てる
+      # 確認対象になる Docker image の数は直近100件
+      #     GitHub API Doc: https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-an-organization
       - name: Check latest docker image tag
         run: |
-          LATEST_TAG=`curl \
+          HIT_IMAGE_NUM=`curl \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ github.token }}" \
-            https://api.github.com/users/Takahiro55555/packages/container/github-actions-etrobocon2021/versions | \
-            jq '.[0].metadata.container.tags' | \
-            grep -vE '(latest)|\[|\]' | \
-            sed -e 's/"//g' | \
-            sed -e 's/,//g' | \
-            sed -e 's/\s//g' || echo ''`
+            https://api.github.com/orgs/KatLab-MiyazakiUniv/packages/container/${{ env.IMAGE }}/versions?per_page=100 | \
+            jq '.[].metadata.container.tags' | \
+            grep ${{ env.TAG }} | \
+            wc -l || echo 0`
           IS_REBUILD_DOCKER_IMAGE='false'
-          [[ ${{ env.TAG }} != $LATEST_TAG ]]; then
+          if [[ 0 == $HIT_IMAGE_NUM ]]; then
             IS_REBUILD_DOCKER_IMAGE='true'
           fi
           echo IS_REBUILD_DOCKER_IMAGE=$IS_REBUILD_DOCKER_IMAGE >> $GITHUB_ENV
 
+      # 指定されたタグの Docker image が無い場合、
+      # 新たに Docker image をビルドし、GitHub Container Registry に Push する
       - name: Build and publish docker image
         if: ${{ env.IS_REBUILD_DOCKER_IMAGE == 'true' }}
         uses: matootie/github-docker@v3.1.0
         with:
           accessToken: ${{ secrets.PAT }}
           imageName: ${{ env.IMAGE }}
-          tag: |
-            latest
-            ${{ env.TAG }}
+          tag: ${{ env.TAG }}
           containerRegistry: true
 
+      # Docker image を GitHub Container Registry から Pull して、
+      # 実際に etrobo 環境でのビルドが実行できるかどうか確認する
       - name: ETRobocon build test
         run: |
           echo ${{ secrets.PAT }} | docker login ghcr.io -u Takahiro55555 --password-stdin
           docker pull ghcr.io/katlab-miyazakiuniv/github-actions-etrobocon2021
-          docker run -v ${{ github.workspace }}:/tmp/etrobocon2021:rw ghcr.io/katlab-miyazakiuniv/github-actions-etrobocon2021
+          docker run -v ${{ github.workspace }}:/tmp/etrobocon2021:rw ghcr.io/katlab-miyazakiuniv/github-actions-etrobocon2021:${{ env.TAG }}

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -38,7 +38,7 @@ jobs:
           HIT_IMAGE_NUM=`curl \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ github.token }}" \
-            https://api.github.com/orgs/KatLab-MiyazakiUniv/packages/container/${{ env.IMAGE }}/versions?per_page=100 | \
+            https://api.github.com/orgs/KatLab-MiyazakiUniv/packages/container/${{ env.IMAGE }}/versions?per_page=100&state=active | \
             jq '.[].metadata.container.tags' | \
             grep ${{ env.TAG }} | \
             wc -l || echo 0`

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -61,6 +61,10 @@ jobs:
 
       # Docker image を GitHub Container Registry から Pull して、
       # 実際に etrobo 環境でのビルドが実行できるかどうか確認する
+      #     GitHub Container Registry Doc: https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+      # FIXME: GitHub Container Registry を使うために、個人の PAT(Personal Access Token)を利用している
+      #        この PAT を Organization または、このリポジトリ用の Token に置き換えること
+      #        また、GitHub Container Registry へのログイン方法もこれで大丈夫なのか心配
       - name: ETRobocon build test
         run: |
           echo ${{ secrets.PAT }} | docker login ghcr.io -u Takahiro55555 --password-stdin

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -50,4 +50,4 @@ jobs:
         run: |
           echo ${{ secrets.PAT }} | docker login ghcr.io -u Takahiro55555 --password-stdin
           docker pull ghcr.io/takahiro55555/github-actions-etrobocon2021
-          docker run -v ${{ github.workspace }}:/tmp/etrobocon:rw ghcr.io/takahiro55555/github-actions-etrobocon2021
+          docker run -v ${{ github.workspace }}:/tmp/etrobocon2021:rw ghcr.io/takahiro55555/github-actions-etrobocon2021

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -13,7 +13,6 @@ jobs:
 
       - name: Create docker image tag
         run: |
-          sudo apt-get install -y jq
           TAG=`curl \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/ETrobocon/etrobo/commits/master?per_page=1 | \

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -13,11 +13,18 @@ jobs:
 
       - name: Create docker image tag
         run: |
+          cat ${{ github.workspace }}/Dockerfile > /tmp/update-check.txt
+          cat ${{ github.workspace }}/entrypoint.sh >> /tmp/update-check.txt
           TAG=`curl \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/ETrobocon/etrobo/commits/master?per_page=1 | \
             jq '.sha' | \
             sed -e 's/"//g'`
+          TAG=${TAG}.`md5sum /tmp/update-check.txt | cut -d ' ' -f 1`
+          echo TAG=$TAG >> $GITHUB_ENV
+      
+      - name: Check latest docker image tag
+        run: |
           LATEST_TAG=`curl \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ github.token }}" \
@@ -28,11 +35,10 @@ jobs:
             sed -e 's/,//g' | \
             sed -e 's/\s//g' || echo ''`
           IS_REBUILD_DOCKER_IMAGE='false'
-          if [ -ne $TAG $LATEST_TAG ]; then
+          [[ ${{ env.TAG }} != $LATEST_TAG ]]; then
             IS_REBUILD_DOCKER_IMAGE='true'
           fi
           echo IS_REBUILD_DOCKER_IMAGE=$IS_REBUILD_DOCKER_IMAGE >> $GITHUB_ENV
-          echo TAG=$TAG >> $GITHUB_ENV
 
       - name: Build and publish docker image
         if: ${{ env.IS_REBUILD_DOCKER_IMAGE == 'true' }}

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -1,0 +1,53 @@
+name: Build check
+on: push
+
+env:
+  IMAGE: github-actions-etrobocon2021
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: Create docker image tag
+        run: |
+          sudo apt-get install -y jq
+          TAG=`curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/ETrobocon/etrobo/commits/master?per_page=1 | \
+            jq '.sha' | \
+            sed -e 's/"//g'`
+          LATEST_TAG=`curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ github.token }}" \
+            https://api.github.com/users/Takahiro55555/packages/container/github-actions-etrobocon2021/versions | \
+            jq '.[0].metadata.container.tags' | \
+            grep -vE '(latest)|\[|\]' | \
+            sed -e 's/"//g' | \
+            sed -e 's/,//g' | \
+            sed -e 's/\s//g' || echo ''`
+          IS_REBUILD_DOCKER_IMAGE='false'
+          if [ -ne $TAG $LATEST_TAG ]; then
+            IS_REBUILD_DOCKER_IMAGE='true'
+          fi
+          echo IS_REBUILD_DOCKER_IMAGE=$IS_REBUILD_DOCKER_IMAGE >> $GITHUB_ENV
+          echo TAG=$TAG >> $GITHUB_ENV
+
+      - name: Build and publish docker image
+        if: ${{ env.IS_REBUILD_DOCKER_IMAGE == 'true' }}
+        uses: matootie/github-docker@v3.1.0
+        with:
+          accessToken: ${{ secrets.PAT }}
+          imageName: ${{ env.IMAGE }}
+          tag: |
+            latest
+            ${{ env.TAG }}
+          containerRegistry: true
+
+      - name: ETRobocon build test
+        run: |
+          echo ${{ secrets.PAT }} | docker login ghcr.io -u Takahiro55555 --password-stdin
+          docker pull ghcr.io/takahiro55555/github-actions-etrobocon2021
+          docker run -v ${{ github.workspace }}:/tmp/etrobocon:rw ghcr.io/takahiro55555/github-actions-etrobocon2021

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:21.04
+
+RUN apt-get update &&\
+    apt-get install -y wget git cmake g++
+
+RUN wget https://raw.githubusercontent.com/ETrobocon/etrobo/master/scripts/startetrobo -O ~/startetrobo && \
+    sed -i -r 's/^(\s*)sudo/\1/g' ~/startetrobo && \
+    chmod +x ~/startetrobo
+
+RUN git config --global user.name docker && \
+    git config --global user.email example@example.com && \
+    ~/startetrobo shell
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh && \
+    mkdir -p /tmp/etrobocon
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,10 @@ fi
 # invoke etrobo environment
 cd "$ETROBO_ROOT"
 
-ln -s /tmp/etrobocon $ETROBO_ROOT/workspace/etrobocon
+ln -s /tmp/etrobocon2021 $ETROBO_ROOT/workspace/etrobocon2021
 
 if [ -z "$ETROBO_ENV" ]; then
     . "$ETROBO_ROOT/scripts/etroboenv.sh" silent
 fi
 
-make app=etrobocon
+make app=etrobocon2021

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+ETROBO_ROOT="${HOME}/etrobo"
+
+# download package
+if [ -d "$ETROBO_ROOT" ]; then
+    "$ETROBO_ROOT/scripts/etrobopkg"
+fi
+
+# install Athrill2 & UnityETroboSim
+"$ETROBO_ROOT/scripts/setup.sh"
+
+# invoke etrobo environment
+cd "$ETROBO_ROOT"
+
+ln -s /tmp/etrobocon $ETROBO_ROOT/workspace/etrobocon
+
+if [ -z "$ETROBO_ENV" ]; then
+    . "$ETROBO_ROOT/scripts/etroboenv.sh" silent
+fi
+
+make app=etrobocon

--- a/module/Controller.cpp
+++ b/module/Controller.cpp
@@ -13,7 +13,8 @@ int Controller::limitPwmValue(const int value)
   } else if(value < MOTOR_PWM_MIN) {
     return MOTOR_PWM_MIN;
   }
-  return value;
+  // わざとビルドに失敗するようにした
+  return value
 }
 
 void Controller::setRightMotorPwm(const int pwm)

--- a/module/Controller.cpp
+++ b/module/Controller.cpp
@@ -13,8 +13,7 @@ int Controller::limitPwmValue(const int value)
   } else if(value < MOTOR_PWM_MIN) {
     return MOTOR_PWM_MIN;
   }
-  // わざとビルドに失敗するようにした
-  return value
+  return value;
 }
 
 void Controller::setRightMotorPwm(const int pwm)


### PR DESCRIPTION
# チェックリスト
- [X] clang-formatしている
- [X] コーディング規約に準じている
- [X] チケットの完了条件を満たしている

# 変更点
- `Dockerfile` の追加
- `entrypoint.sh` の追加
- `.github/workflows/build-check.yaml` の追加

## 処理の流れ
1. ビルド確認に使用する Docker image のタグを作成する
    1.1. [ETrobocon/etrobo](https://github.com/ETrobocon/etrobo)の`master`ブランチにおける最新のコミットIDを取得
    1.2. `Dockerfile`と`entrypoint.sh`を結合したファイルのハッシュ値を計算
    1.3. 上記で取得したコミットIDとハッシュ値を結合し、Docker image のタグとする

2. 上記で作成したタグが付与された Docker image が存在するかどうかを確認する
    2.1. 直近ビルドされた Docker image のタグを最大100件取得する
    2.2. `1.3.` で作成したタグが存在するか確認し、存在しない場合 Docker image をビルドするためのフラグを立てる

3. Docker image をビルドするためのフラグが立っている場合、ビルドを実行し GitHub Container Registry に Push する

4. ビルドの確認を行う
    4.1. GitHub Container Registry にログインする
    4.2. GitHub Container Registry から `1.3.` で作成したタグが付与されている Docker image を Pull する
    4.3. Docker コンテナに、このGitHubリポジトリのルートディレクトリをマウントし、Dockerコンテナを起動する
    4.5. 起動した Docker コンテナの `/entrypoint.sh` が実行され、ビルドの確認が行われる

## 動作確認結果
### ビルド成功例
- [fix: ビルドエラーを訂正 Build check #9](https://github.com/KatLab-MiyazakiUniv/etrobocon2021/runs/2773839139?check_suite_focus=true)

### ビルド失敗例
- [fix: jq のエラーを回避（したはず...） Build check #8](https://github.com/KatLab-MiyazakiUniv/etrobocon2021/runs/2773790604?check_suite_focus=true)

### Docker image のビルド例
- [update: Docker image の際ビルドの判定方法を変更、コメントを追記 Build check #6](https://github.com/KatLab-MiyazakiUniv/etrobocon2021/runs/2773523392?check_suite_focus=true)

## 備考
このプルリクが Merge されたら、プルリクを Merge する際の必要条件に「ビルドの確認に成功すること」を追記する予定です。

シミュレータテストが実現したら必要なさそうという意見もあるかもしれません。
個人的に、以下の理由からこの workflow を作成しました。
- シミュレータテストが実現しても、オンプレミス環境で動作させるため安定性に疑問が残るため、プルリクの Merge の条件には加える予定は無い（今のところ & 個人的見解）
- 来年以降も利用する際、シミュレータテストよりも使いまわせる可能性が高い
