### PR TITLE
close #54 Controller クラスに競技終了通知処理を追加した

### DIFF
--- a/module/Controller.cpp
+++ b/module/Controller.cpp
@@ -51,3 +51,9 @@ void Controller::sleep(int milliSec)
 {
   clock.sleep(milliSec);
 }
+
+//シミュレータへ競技の終了を通知する
+void Controller::notifyCompletedToSimulator()
+{
+  ETRoboc_notifyCompletedToSimulator();
+}

--- a/module/Controller.h
+++ b/module/Controller.h
@@ -7,6 +7,7 @@
 #define CONTROLLER_H
 
 #include "ev3api.h"
+#include "etroboc_ext.h"
 #include "Motor.h"
 #include "Clock.h"
 #include "Measurer.h"
@@ -40,6 +41,11 @@ class Controller {
    * @param milliSec スリープ時間(ミリ秒)
    */
   void sleep(int milliSec = 10);
+
+  /**
+   * シミュレータへ競技の終了を通知する
+   */
+  void notifyCompletedToSimulator();
 
  private:
   ev3api::Motor rightWheel;

--- a/module/EtRobocon2021.cpp
+++ b/module/EtRobocon2021.cpp
@@ -18,4 +18,7 @@ void EtRobocon2021::start()
 
   //ライントレースエリア攻略開始
   LineTraceArea::runLineTraceArea();
+
+  //シミュレータへ競技の終了を通知する
+  controller.notifyCompletedToSimulator();
 }

--- a/test/dummy/etroboc_ext.h
+++ b/test/dummy/etroboc_ext.h
@@ -1,0 +1,7 @@
+/**
+ * @file etroboc_ext.h.h
+ * @brief EV3拡張API（ダミー）
+ * @author Takahiro55555
+ */
+
+inline static void ETRoboc_notifyCompletedToSimulator(void){}


### PR DESCRIPTION
# チェックリスト
- [X] clang-formatしている
- [X] コーディング規約に準じている
- [X] チケットの完了条件を満たしている
# 変更点
- シミュレータへの競技終了通知を `Controller` クラスから行えるようにした
- Google Test のためにダミーファイルとして `etroboc_ext.h` を追加した

## 関連資料
- [ETRoboc_notifyCompletedToSimulator - 競技終了通知](https://github.com/ETrobocon/etrobo/wiki/sim_extended_api#etroboc_notifycompletedtosimulator---%E7%AB%B6%E6%8A%80%E7%B5%82%E4%BA%86%E9%80%9A%E7%9F%A5)
