### PR TITLE
close #68 色を取得・識別する

### DIFF
--- a/module/ColorJudge.cpp
+++ b/module/ColorJudge.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file ColorJudge.cpp
+ * @brief 色識別クラス
+ * @author hiroto0927, miyashita64
+ */
+
+#include "ColorJudge.h"
+
+ColorJudge::ColorJudge() {}
+
+// RGBをHSVに変形し、色を判別する
+COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
+{
+  int hue = 0;         // 色相(0-360)
+  int saturation = 0;  // 彩度(0-100)
+  int value = 0;       // 明度(0-255)
+
+  rgb_raw_t rgb;
+
+  // 環境光を打ち消す
+  rgb.r = (_rgb.r < MAX_RGB.r) ? _rgb.r * 256 / MAX_RGB.r : 256;
+  rgb.g = (_rgb.g < MAX_RGB.g) ? _rgb.g * 256 / MAX_RGB.g : 256;
+  rgb.b = (_rgb.b < MAX_RGB.b) ? _rgb.b * 256 / MAX_RGB.b : 256;
+
+  // RGBの中の最大・最小値を求める
+  int max = (rgb.r > rgb.g && rgb.r > rgb.b) ? rgb.r : (rgb.g > rgb.b) ? rgb.g : rgb.b;
+  int min = (rgb.r < rgb.g && rgb.r < rgb.b) ? rgb.r : (rgb.g < rgb.b) ? rgb.g : rgb.b;
+
+  if(max == 0) {
+    return COLOR::BLACK;
+  }
+  saturation = 100 * (max - min) / max;
+  value = max;
+
+  // 明度が極端に低ければ、黒を返す
+  if(value < BLACK_LIMIT_BORDER) return COLOR::BLACK;
+  // 明度が極端に高ければ、白を返す
+  if(min > WHITE_LIMIT_BORDER) return COLOR::WHITE;
+  // 彩度が低い場合
+  if(saturation < SATURATION_BORDER) {
+    // 明度が低ければ、黒を返す
+    if(value < BLACK_BORDER) return COLOR::BLACK;
+  }
+
+  // 色相を計算
+  if(max == min) {
+    hue = 0;
+  } else if(rgb.r == max) {
+    hue = 60 * (rgb.g - rgb.b) / (max - min);
+  } else if(rgb.g == max) {
+    hue = 60 * (rgb.b - rgb.r) / (max - min) + 120;
+  } else if(rgb.b == max) {
+    hue = 60 * (rgb.r - rgb.g) / (max - min) + 240;
+  }
+
+  // マイナスの場合の補完
+  hue = (hue + 360) % 360;
+
+  // 各境界によって、色を判別する
+  if(hue < RED_BORDER) return COLOR::RED;
+  if(hue < YELLOW_BORDER) return COLOR::YELLOW;
+  if(hue < GREEN_BORDER) return COLOR::GREEN;
+  if(hue < BLUE_BORDER) return COLOR::BLUE;
+  return COLOR::RED;
+}

--- a/module/ColorJudge.cpp
+++ b/module/ColorJudge.cpp
@@ -6,8 +6,6 @@
 
 #include "ColorJudge.h"
 
-ColorJudge::ColorJudge() {}
-
 // RGBから色を判別する
 COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
 {
@@ -22,7 +20,7 @@ COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
   rgb.b = (_rgb.b < MAX_RGB.b) ? _rgb.b * 255 / MAX_RGB.b : 255;
 
   // HSV値に変換
-  hsv = ColorJudge::getHsv(rgb);
+  hsv = getHsv(rgb);
 
   // RGBの中の最小値を求める
   min = std::min({ _rgb.r, _rgb.g, _rgb.b });

--- a/module/ColorJudge.cpp
+++ b/module/ColorJudge.cpp
@@ -8,58 +8,74 @@
 
 ColorJudge::ColorJudge() {}
 
-// RGBをHSVに変形し、色を判別する
+// RGBから色を判別する
 COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
 {
-  int hue = 0;         // 色相(0-360)
-  int saturation = 0;  // 彩度(0-100)
-  int value = 0;       // 明度(0-255)
-
   rgb_raw_t rgb;
+  hsv_raw_t hsv;
+  int min;
 
-  // 環境光を打ち消す
+  // 環境光による値の偏りを軽減する
+  // 事前に測った白が(255,255,255)となるように、RGB値を変換する
   rgb.r = (_rgb.r < MAX_RGB.r) ? _rgb.r * 256 / MAX_RGB.r : 256;
   rgb.g = (_rgb.g < MAX_RGB.g) ? _rgb.g * 256 / MAX_RGB.g : 256;
   rgb.b = (_rgb.b < MAX_RGB.b) ? _rgb.b * 256 / MAX_RGB.b : 256;
 
-  // RGBの中の最大・最小値を求める
-  int max = (rgb.r > rgb.g && rgb.r > rgb.b) ? rgb.r : (rgb.g > rgb.b) ? rgb.g : rgb.b;
-  int min = (rgb.r < rgb.g && rgb.r < rgb.b) ? rgb.r : (rgb.g < rgb.b) ? rgb.g : rgb.b;
+  // HSV値に変換
+  hsv = ColorJudge::getHsv(rgb);
 
-  if(max == 0) {
-    return COLOR::BLACK;
-  }
-  saturation = 100 * (max - min) / max;
-  value = max;
+  // RGBの中の最小値を求める
+  min = std::min({ _rgb.r, _rgb.g, _rgb.b });
 
   // 明度が極端に低ければ、黒を返す
-  if(value < BLACK_LIMIT_BORDER) return COLOR::BLACK;
+  if(hsv.value < BLACK_LIMIT_BORDER) return COLOR::BLACK;
   // 明度が極端に高ければ、白を返す
   if(min > WHITE_LIMIT_BORDER) return COLOR::WHITE;
   // 彩度が低い場合
-  if(saturation < SATURATION_BORDER) {
+  if(hsv.saturation < SATURATION_BORDER) {
     // 明度が低ければ、黒を返す
-    if(value < BLACK_BORDER) return COLOR::BLACK;
+    if(hsv.value < BLACK_BORDER) return COLOR::BLACK;
   }
 
-  // 色相を計算
+  // 各色相の境界によって、色を判別する
+  if(hsv.hue < RED_BORDER) return COLOR::RED;
+  if(hsv.hue < YELLOW_BORDER) return COLOR::YELLOW;
+  if(hsv.hue < GREEN_BORDER) return COLOR::GREEN;
+  if(hsv.hue < BLUE_BORDER) return COLOR::BLUE;
+  return COLOR::RED;
+}
+
+// RGBをHSVに変換する
+hsv_raw_t ColorJudge::getHsv(rgb_raw_t const& _rgb)
+{
+  hsv_raw_t hsv{ 0, 0, 0 };
+
+  // RGBの中の最大・最小値を求める
+  int max = std::max({ _rgb.r, _rgb.g, _rgb.b });
+  int min = std::min({ _rgb.r, _rgb.g, _rgb.b });
+
+  // maxが0の場合、黒を返す
+  if(max == 0) {
+    return hsv;
+  }
+
+  // 彩度
+  hsv.saturation = 100 * (max - min) / max;
+  // 輝度
+  hsv.value = max;
+  // 色相
   if(max == min) {
-    hue = 0;
-  } else if(rgb.r == max) {
-    hue = 60 * (rgb.g - rgb.b) / (max - min);
-  } else if(rgb.g == max) {
-    hue = 60 * (rgb.b - rgb.r) / (max - min) + 120;
-  } else if(rgb.b == max) {
-    hue = 60 * (rgb.r - rgb.g) / (max - min) + 240;
+    hsv.hue = 0;
+  } else if(_rgb.r == max) {
+    hsv.hue = 60 * (_rgb.g - _rgb.b) / (max - min);
+  } else if(_rgb.g == max) {
+    hsv.hue = 60 * (_rgb.b - _rgb.r) / (max - min) + 120;
+  } else if(_rgb.b == max) {
+    hsv.hue = 60 * (_rgb.r - _rgb.g) / (max - min) + 240;
   }
 
   // マイナスの場合の補完
-  hue = (hue + 360) % 360;
+  hsv.hue = (hsv.hue + 360) % 360;
 
-  // 各境界によって、色を判別する
-  if(hue < RED_BORDER) return COLOR::RED;
-  if(hue < YELLOW_BORDER) return COLOR::YELLOW;
-  if(hue < GREEN_BORDER) return COLOR::GREEN;
-  if(hue < BLUE_BORDER) return COLOR::BLUE;
-  return COLOR::RED;
+  return hsv;
 }

--- a/module/ColorJudge.cpp
+++ b/module/ColorJudge.cpp
@@ -15,9 +15,9 @@ COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
 
   // 環境光による値の偏りを軽減する
   // 事前に測った白が(255,255,255)となるように、RGB値を変換する
-  rgb.r = (_rgb.r < MAX_RGB.r) ? _rgb.r * 255 / MAX_RGB.r : 255;
-  rgb.g = (_rgb.g < MAX_RGB.g) ? _rgb.g * 255 / MAX_RGB.g : 255;
-  rgb.b = (_rgb.b < MAX_RGB.b) ? _rgb.b * 255 / MAX_RGB.b : 255;
+  rgb.r = (_rgb.r < MAX_RGB.r) ? (_rgb.r - MIN_RGB.r) * 255 / (MAX_RGB.r - MIN_RGB.r) : 255;
+  rgb.g = (_rgb.g < MAX_RGB.g) ? (_rgb.g - MIN_RGB.g) * 255 / (MAX_RGB.g - MIN_RGB.g) : 255;
+  rgb.b = (_rgb.b < MAX_RGB.b) ? (_rgb.b - MIN_RGB.b) * 255 / (MAX_RGB.b - MIN_RGB.b) : 255;
 
   // HSV値に変換
   hsv = convertRgbToHsv(rgb);
@@ -33,6 +33,8 @@ COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
   if(hsv.saturation < SATURATION_BORDER) {
     // 明度が低ければ、黒を返す
     if(hsv.value < BLACK_BORDER) return COLOR::BLACK;
+    // 明度が高ければ、白を返す
+    return COLOR::WHITE;
   }
 
   // 各色相の境界によって、色を判別する

--- a/module/ColorJudge.cpp
+++ b/module/ColorJudge.cpp
@@ -10,7 +10,7 @@
 COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
 {
   rgb_raw_t rgb;
-  hsv_raw_t hsv;
+  Hsv hsv;
   int min;
 
   // 環境光による値の偏りを軽減する
@@ -20,7 +20,7 @@ COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
   rgb.b = (_rgb.b < MAX_RGB.b) ? _rgb.b * 255 / MAX_RGB.b : 255;
 
   // HSV値に変換
-  hsv = getHsv(rgb);
+  hsv = convertRgbToHsv(rgb);
 
   // RGBの中の最小値を求める
   min = std::min({ _rgb.r, _rgb.g, _rgb.b });
@@ -44,9 +44,9 @@ COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
 }
 
 // RGBをHSVに変換する
-hsv_raw_t ColorJudge::getHsv(rgb_raw_t const& _rgb)
+Hsv ColorJudge::convertRgbToHsv(rgb_raw_t const& _rgb)
 {
-  hsv_raw_t hsv{ 0, 0, 0 };
+  Hsv hsv{ 0, 0, 0 };
 
   // RGBの中の最大・最小値を求める
   int max = std::max({ _rgb.r, _rgb.g, _rgb.b });

--- a/module/ColorJudge.cpp
+++ b/module/ColorJudge.cpp
@@ -17,9 +17,9 @@ COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
 
   // 環境光による値の偏りを軽減する
   // 事前に測った白が(255,255,255)となるように、RGB値を変換する
-  rgb.r = (_rgb.r < MAX_RGB.r) ? _rgb.r * 256 / MAX_RGB.r : 256;
-  rgb.g = (_rgb.g < MAX_RGB.g) ? _rgb.g * 256 / MAX_RGB.g : 256;
-  rgb.b = (_rgb.b < MAX_RGB.b) ? _rgb.b * 256 / MAX_RGB.b : 256;
+  rgb.r = (_rgb.r < MAX_RGB.r) ? _rgb.r * 255 / MAX_RGB.r : 255;
+  rgb.g = (_rgb.g < MAX_RGB.g) ? _rgb.g * 255 / MAX_RGB.g : 255;
+  rgb.b = (_rgb.b < MAX_RGB.b) ? _rgb.b * 255 / MAX_RGB.b : 255;
 
   // HSV値に変換
   hsv = ColorJudge::getHsv(rgb);

--- a/module/ColorJudge.h
+++ b/module/ColorJudge.h
@@ -36,7 +36,7 @@ class ColorJudge {
   static COLOR getColor(rgb_raw_t const& rgb);
 
  private:
-  static constexpr int SATURATION_BORDER = 50;  // 無彩色かの彩度の境界
+  static constexpr int SATURATION_BORDER = 7;  // 無彩色かの彩度の境界
 
   static constexpr int BLACK_LIMIT_BORDER = 50;  // 黒の明度の境界
   static constexpr int WHITE_LIMIT_BORDER = 90;  // 白の明度の境界
@@ -47,6 +47,7 @@ class ColorJudge {
   static constexpr int GREEN_BORDER = 165;                 // 緑の色相の境界
   static constexpr int BLUE_BORDER = 300;                  // 青の色相の境界
   static constexpr rgb_raw_t MAX_RGB = { 112, 107, 152 };  //コースが白の時（最大）のRGB値
+  static constexpr rgb_raw_t MIN_RGB = { 4, 5, 8 };  //コースが黒の時（最小）のRGB値
   ColorJudge();
   static Hsv convertRgbToHsv(rgb_raw_t const& rgb);
 };

--- a/module/ColorJudge.h
+++ b/module/ColorJudge.h
@@ -1,0 +1,46 @@
+/**
+ * @file ColorJudge.h
+ * @brief 色識別クラス
+ * @author hiroto0927, miyashita64
+ */
+
+#ifndef COLOR_JUDGE_H
+#define COLOR_JUDGE_H
+
+#include "Measurer.h"
+
+enum class COLOR : int {
+  NONE = 0,
+  BLACK = 1,
+  BLUE = 2,
+  GREEN = 3,
+  YELLOW = 4,
+  RED = 5,
+  WHITE = 6,
+};
+
+class ColorJudge {
+ public:
+  /**
+   * 与えられたRGB値から、何色かを返す
+   * @param rgb RGB値の参照
+   * @return 色
+   */
+  static COLOR getColor(rgb_raw_t const& rgb);
+
+ private:
+  static constexpr int SATURATION_BORDER = 50;  // 無彩色かの彩度の境界
+
+  static constexpr int BLACK_LIMIT_BORDER = 50;  // 黒の明度の境界
+  static constexpr int WHITE_LIMIT_BORDER = 90;  // 白の明度の境界
+  static constexpr int BLACK_BORDER = 100;       // 無彩色の黒の明度の境界
+
+  static constexpr int RED_BORDER = 30;                    // 赤の色相の境界
+  static constexpr int YELLOW_BORDER = 75;                 // 黄の色相の境界
+  static constexpr int GREEN_BORDER = 165;                 // 緑の色相の境界
+  static constexpr int BLUE_BORDER = 300;                  // 青の色相の境界
+  static constexpr rgb_raw_t MAX_RGB = { 112, 107, 152 };  //コースが白の時（最大）のRGB値
+  ColorJudge();
+};
+
+#endif

--- a/module/ColorJudge.h
+++ b/module/ColorJudge.h
@@ -20,11 +20,11 @@ enum class COLOR : int {
   WHITE = 6,
 };
 
-typedef struct {
+struct Hsv {
   int hue;         // 色相(0-360)
   int saturation;  // 彩度(0-100)
   int value;       // 明度(0-255)
-} hsv_raw_t;
+};
 
 class ColorJudge {
  public:
@@ -48,7 +48,7 @@ class ColorJudge {
   static constexpr int BLUE_BORDER = 300;                  // 青の色相の境界
   static constexpr rgb_raw_t MAX_RGB = { 112, 107, 152 };  //コースが白の時（最大）のRGB値
   ColorJudge();
-  static hsv_raw_t getHsv(rgb_raw_t const& rgb);
+  static Hsv convertRgbToHsv(rgb_raw_t const& rgb);
 };
 
 #endif

--- a/module/ColorJudge.h
+++ b/module/ColorJudge.h
@@ -7,6 +7,7 @@
 #ifndef COLOR_JUDGE_H
 #define COLOR_JUDGE_H
 
+#include <algorithm>
 #include "Measurer.h"
 
 enum class COLOR : int {
@@ -18,6 +19,12 @@ enum class COLOR : int {
   RED = 5,
   WHITE = 6,
 };
+
+typedef struct {
+  int hue;         // 色相(0-360)
+  int saturation;  // 彩度(0-100)
+  int value;       // 明度(0-255)
+} hsv_raw_t;
 
 class ColorJudge {
  public:
@@ -41,6 +48,7 @@ class ColorJudge {
   static constexpr int BLUE_BORDER = 300;                  // 青の色相の境界
   static constexpr rgb_raw_t MAX_RGB = { 112, 107, 152 };  //コースが白の時（最大）のRGB値
   ColorJudge();
+  static hsv_raw_t getHsv(rgb_raw_t const& rgb);
 };
 
 #endif

--- a/module/Measurer.cpp
+++ b/module/Measurer.cpp
@@ -17,6 +17,14 @@ int Measurer::getBrightness()
   return colorSensor.getBrightness();
 }
 
+// RGB値を返す
+rgb_raw_t Measurer::getRawColor()
+{
+  rgb_raw_t rgb;
+  colorSensor.getRawColor(rgb);
+  return rgb;
+}
+
 //左モータ角位置取得
 int Measurer::getLeftCount()
 {

--- a/module/Measurer.h
+++ b/module/Measurer.h
@@ -26,6 +26,12 @@ class Measurer {
   int getBrightness();
 
   /**
+   * RGB値を取得
+   * @return RGB値
+   */
+  rgb_raw_t getRawColor();
+
+  /**
    * 左モータ角位置取得
    * @return 左モータ角位置[deg]
    */

--- a/test/ColorJudgeTest.cpp
+++ b/test/ColorJudgeTest.cpp
@@ -8,8 +8,7 @@
 #include <gtest/gtest.h>
 
 namespace etrobocon2021_test {
-  // 彩度の境界値テスト
-  TEST(getColorTest, getColorByBlack)
+  TEST(getColorTest, getColorTrueBlack)
   {
     rgb_raw_t rgb = { 0, 0, 0 };
     COLOR expected = COLOR::BLACK;
@@ -17,7 +16,167 @@ namespace etrobocon2021_test {
     EXPECT_EQ(expected, ColorJudge::getColor(rgb));
   }
 
-  TEST(getColorTest, getColorByMax)
+  TEST(getColorTest, getColorLightBlack)
+  {
+    rgb_raw_t rgb = { 39, 39, 58 };
+    COLOR expected = COLOR::BLACK;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkBlack)
+  {
+    rgb_raw_t rgb = { 4, 5, 8 };
+    COLOR expected = COLOR::BLACK;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightRed)
+  {
+    rgb_raw_t rgb = { 119, 81, 109 };
+    COLOR expected = COLOR::RED;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkRed)
+  {
+    rgb_raw_t rgb = { 111, 19, 19 };
+    COLOR expected = COLOR::RED;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightRed2)
+  {
+    rgb_raw_t rgb = { 103, 90, 128 };
+    COLOR expected = COLOR::RED;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkRed2)
+  {
+    rgb_raw_t rgb = { 93, 16, 16 };
+    COLOR expected = COLOR::RED;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightYellow)
+  {
+    rgb_raw_t rgb = { 120, 108, 71 };
+    COLOR expected = COLOR::YELLOW;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkYellow)
+  {
+    rgb_raw_t rgb = { 120, 104, 8 };
+    COLOR expected = COLOR::YELLOW;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightYellow2)
+  {
+    rgb_raw_t rgb = { 104, 96, 71 };
+    COLOR expected = COLOR::YELLOW;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkYellow2)
+  {
+    rgb_raw_t rgb = { 104, 92, 8 };
+    COLOR expected = COLOR::YELLOW;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightGreen)
+  {
+    rgb_raw_t rgb = { 72, 100, 106 };
+    COLOR expected = COLOR::GREEN;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkGreen)
+  {
+    rgb_raw_t rgb = { 4, 75, 35 };
+    COLOR expected = COLOR::GREEN;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightGreen2)
+  {
+    rgb_raw_t rgb = { 85, 94, 124 };
+    COLOR expected = COLOR::GREEN;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkGreen2)
+  {
+    rgb_raw_t rgb = { 4, 64, 29 };
+    COLOR expected = COLOR::GREEN;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightBlue)
+  {
+    rgb_raw_t rgb = { 81, 92, 144 };
+    COLOR expected = COLOR::BLUE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkBlue)
+  {
+    rgb_raw_t rgb = { 4, 45, 112 };
+    COLOR expected = COLOR::BLUE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightBlue2)
+  {
+    rgb_raw_t rgb = { 83, 89, 137 };
+    COLOR expected = COLOR::BLUE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkBlue2)
+  {
+    rgb_raw_t rgb = { 4, 40, 103 };
+    COLOR expected = COLOR::BLUE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorLightWhite)
+  {
+    rgb_raw_t rgb = { 104, 101, 146 };
+    COLOR expected = COLOR::WHITE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorDarkWhite)
+  {
+    rgb_raw_t rgb = { 92, 94, 141 };
+    COLOR expected = COLOR::WHITE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorMaxRgb)
   {
     rgb_raw_t rgb = { 112, 107, 152 };
     COLOR expected = COLOR::WHITE;

--- a/test/ColorJudgeTest.cpp
+++ b/test/ColorJudgeTest.cpp
@@ -1,0 +1,28 @@
+/**
+ * @file ColorJudgeTest.cpp
+ * @brief ColorJudgeクラスをテストする
+ * @author hiroto0927, miyashita64
+ */
+
+#include "ColorJudge.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2021_test {
+  // 彩度の境界値テスト
+  TEST(getColorTest, getColorByBlack)
+  {
+    rgb_raw_t rgb = { 0, 0, 0 };
+    COLOR expected = COLOR::BLACK;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+  TEST(getColorTest, getColorByMax)
+  {
+    rgb_raw_t rgb = { 112, 107, 152 };
+    COLOR expected = COLOR::WHITE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
+
+}  // namespace etrobocon2021_test

--- a/test/ColorJudgeTest.cpp
+++ b/test/ColorJudgeTest.cpp
@@ -184,4 +184,11 @@ namespace etrobocon2021_test {
     EXPECT_EQ(expected, ColorJudge::getColor(rgb));
   }
 
+  TEST(getColorTest, getColorFullRgb)
+  {
+    rgb_raw_t rgb = { 255, 255, 255 };
+    COLOR expected = COLOR::WHITE;
+
+    EXPECT_EQ(expected, ColorJudge::getColor(rgb));
+  }
 }  // namespace etrobocon2021_test

--- a/test/MeasurerTest.cpp
+++ b/test/MeasurerTest.cpp
@@ -1,0 +1,18 @@
+/**
+ * @file MeasurerTest.cpp
+ * @brief Measurerクラスをテストする
+ * @author hiroto0927, miyashita64
+ */
+
+#include "Measurer.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2021_test {
+  TEST(getRawColorTest, getRawColorRed)
+  {
+    Measurer measurer;
+    int expected = 8;
+
+    EXPECT_EQ(expected, measurer.getRawColor().r);
+  }
+}  // namespace etrobocon2021_test

--- a/test/dummy/ColorSensor.cpp
+++ b/test/dummy/ColorSensor.cpp
@@ -19,5 +19,5 @@ int ColorSensor::getBrightness()
 // RGB値を取得
 void ColorSensor::getRawColor(rgb_raw_t& rgb)
 {
-  rgb = rawColor;
+  rgb = { 8, 9, 10 };
 }

--- a/test/dummy/ColorSensor.cpp
+++ b/test/dummy/ColorSensor.cpp
@@ -8,12 +8,16 @@
 using namespace ev3api;
 
 //コンストラクタ
-  ColorSensor::ColorSensor(ePortS port)
-{
-}
+ColorSensor::ColorSensor(ePortS port) {}
 
 //明るさを取得
 int ColorSensor::getBrightness()
 {
   return brightness;
+}
+
+// RGB値を取得
+void ColorSensor::getRawColor(rgb_raw_t& rgb)
+{
+  rgb = rawColor;
 }

--- a/test/dummy/ColorSensor.h
+++ b/test/dummy/ColorSensor.h
@@ -9,12 +9,17 @@
 
 #include "Port.h"
 
+typedef struct {
+  int r, g, b;
+} rgb_raw_t;
+
 namespace ev3api {
 
   //カラーセンサクラス
   class ColorSensor {
    public:
     int brightness = 0;
+    rgb_raw_t rawColor = { 8, 9, 10 };
 
     /**
      * コンストラクタ
@@ -28,6 +33,12 @@ namespace ev3api {
      * @return 反射光の強さ(0-100)
      */
     int getBrightness();  //明るさを取得
+
+    /**
+     * RGB値を取得
+     * @return RGBを保持するクラス
+     */
+    void getRawColor(rgb_raw_t& rgb);
   };
 }  // namespace ev3api
 

--- a/test/dummy/ColorSensor.h
+++ b/test/dummy/ColorSensor.h
@@ -19,7 +19,6 @@ namespace ev3api {
   class ColorSensor {
    public:
     int brightness = 0;
-    rgb_raw_t rawColor = { 8, 9, 10 };
 
     /**
      * コンストラクタ


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- Measurerクラスに、getColorId()を追加
- ColorJudge.h, ColorJudge.cpp を作成
- MeasurerTest.cpp, ColorJudgeTest.cpp を作成
- ColorSensorクラスに色識別に関するダミーを追加

# 動作テスト

## 実験方法
- 1 : シミュレータの環境設定で初期位置を変えながら、ColorJudgeクラスを使って色を表示させた。
- 2 : シミュレーターの環境設定で環境光（4パターン）と影の位置（4パターン）をそれぞれ条件を変更させ、正しく色を取得できるか確認した。


## 実験結果
以下、実験した範囲では正しく判定できていた
- Lコース上辺　右から　青赤緑
- Lコース上辺　右から　青赤緑 
- Rコース下辺　左から　青赤緑
- Lコース下辺　右から　青赤緑
- Rコース上辺　左から　赤緑黄
- Rコース下辺　左から　青赤緑
- Lコース中辺　下から　赤緑
- Lコース右辺　下から　青木赤 
- Lコース左辺　下から　緑青黄
- Lコース左辺　上から　黄青緑

以下、実験した範囲では正しく判定できていた
- 環境光1 影の位置1
- 環境光1 影の位置2
- 環境光1 影の位置3
- 環境光1 影の位置4
- 環境光2 影の位置1
- 環境光2 影の位置2
- 環境光2 影の位置3
- 環境光2 影の位置4
- 環境光3 影の位置1
- 環境光3 影の位置2
- 環境光3 影の位置3
- 環境光3 影の位置4
- 環境光4 影の位置1
- 環境光4 影の位置2
- 環境光4 影の位置3
- 環境光4 影の位置4


## 添付資料
- Lコース上辺　右から　青赤緑

https://user-images.githubusercontent.com/83441177/123477312-d2517b00-d638-11eb-8f4e-0e1cb736c0b9.mp4

- 修正後の動画

https://user-images.githubusercontent.com/83230897/123960533-58c7dd00-d9ea-11eb-963f-2dc3672e94f8.mp4



