### PR TITLE
close #48 Google Test を実行する workflow のトリガーに関して

### DIFF
--- a/.github/workflows/google-test.yaml
+++ b/.github/workflows/google-test.yaml
@@ -1,15 +1,14 @@
 name: Google Test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
-  build:
+  test:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
-    - name: setup # TODO: この部分をキャッシュする
-      run: sudo apt install cmake -y
+
     - name: test
       run: ./gtest_all.sh


### PR DESCRIPTION
# チェックリスト

- [X] clang-format している
- [X] コーディング規約に準じている
- [X] チケットの完了条件を満たしている


# 変更点
 プルリクを出した後、再度 Push を行うと Google Test が2つ同時に実行される問題を解消した。
細かな変更点は以下の通り。
- workflow の起動条件から `pull_request` を削除
- 実行環境を Ubuntu 18.04 から Ubuntu 20.04 に変更
- 無駄な cmake のインストール処理を削除（GitHub Actions の実行環境に最初から用意されていた）
- jobの名前?を`build` -> `test` に変更

# 動作テスト
このプルリクをもって動作テストとする。
