### PR TITLE
close #70 モータをリセットしないようにする

### DIFF
--- a/module/Controller.cpp
+++ b/module/Controller.cpp
@@ -36,16 +36,6 @@ void Controller::stopMotor()
   rightWheel.stop();
 }
 
-//モータカウントをリセット
-void Controller::resetMotorCount()
-{
-  while((measurer.getLeftCount() != 0) || (measurer.getRightCount() != 0)) {
-    leftWheel.reset();
-    rightWheel.reset();
-    this->sleep();
-  }
-}
-
 //スリープ
 void Controller::sleep(int milliSec)
 {

--- a/module/Controller.h
+++ b/module/Controller.h
@@ -27,11 +27,6 @@ class Controller {
   void setLeftMotorPwm(const int pwm);
 
   /**
-   *モータカウントリセット
-   */
-  void resetMotorCount();
-
-  /**
    * 停止する
    */
   void stopMotor();

--- a/module/LineTracer.cpp
+++ b/module/LineTracer.cpp
@@ -10,6 +10,7 @@ LineTracer::LineTracer(bool _isLeftEdge) : isLeftEdge(_isLeftEdge) {}
 //設定された距離を走行する
 void LineTracer::run(double targetDistance, int targetBrightness, int pwm, const PidGain& gain)
 {
+  double initialDistance = 0;
   double currentDistance = 0;
   double currentPid = 0;
   int pidSign = 0;
@@ -17,13 +18,14 @@ void LineTracer::run(double targetDistance, int targetBrightness, int pwm, const
 
   //左右で符号を変える
   pidSign = (isLeftEdge) ? -1 : 1;
-  //走行距離のリセット
-  controller.resetMotorCount();
+
+  // 初期値を格納
+  initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
 
   //走行距離が目標距離に到達するまで繰り返す
   while(true) {
     currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
-    if(currentDistance >= targetDistance) {
+    if(currentDistance - initialDistance >= targetDistance) {
       break;
     }
     // PID計算

--- a/test/dummy/Motor.cpp
+++ b/test/dummy/Motor.cpp
@@ -21,9 +21,3 @@ void Motor::setPWM(int pwm)
 {
   count += pwm * 0.05;
 }
-
-//モータカウントリセット
-void Motor::reset()
-{
-  count = 0;
-}

--- a/test/dummy/Motor.h
+++ b/test/dummy/Motor.h
@@ -37,11 +37,6 @@ namespace ev3api {
      * @param pwm pwm値
      */
     void setPWM(int pwm);
-    
-    /**
-     * モータカウントリセット
-     */
-    void reset();
 
     /**
      * 停止する


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点

- ControllerクラスのresetMotorCount()を消去
- test/dummyのMotorのresetを消去
- LineTracer::run()内でresetMotorCount()を使わない処理に変更

# 動作テスト

resetMotorCount()する度に走行体がカクつく問題を解消した
## 変更前

https://user-images.githubusercontent.com/56989154/122791834-8d55dd80-d2f4-11eb-97fc-1bef99a41ecb.mp4

## 変更後

https://user-images.githubusercontent.com/56989154/122792141-d5750000-d2f4-11eb-9ae4-df2e9334bc05.mp4


