### PR TITLE
close #59 ライントレースエリアの検証、PID調整

### DIFF
--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -8,13 +8,14 @@
 
 // Lコースの情報を初期化する
 const std::array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::LEFT_COURSE_INFO
-    = { SectionParam{ 1625.340, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 594.506, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 690.288, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 511.724, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 1709.700, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 309.562, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 807.404, 20, 30, PidGain(0.8, 0.01, 0.01) } };
+    = { SectionParam{ 150, 12, 60, PidGain(0.1, 0.8, 0.1) },
+        SectionParam{ 1445, 12, 100, PidGain(3.5, 1, 1) },
+        SectionParam{ 670, 12, 55, PidGain(1, 0.8, 1) },
+        SectionParam{ 600, 12, 100, PidGain(3, 2.7, 1.2) },
+        SectionParam{ 580, 12, 60, PidGain(0.9, 0.3, 0.6) },
+        SectionParam{ 1450, 12, 100, PidGain(2, 0.9, 0.9) },
+        SectionParam{ 400, 12, 50, PidGain(5, 0.8, 0.9) },
+        SectionParam{ 1000, 12, 100, PidGain(3, 1, 0.8) } };
 
 // Rコースの情報を初期化する
 const std::array<SectionParam, LineTraceArea::RIGHT_SECTION_SIZE> LineTraceArea::RIGHT_COURSE_INFO

--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -19,13 +19,14 @@ const std::array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::
 
 // Rコースの情報を初期化する
 const std::array<SectionParam, LineTraceArea::RIGHT_SECTION_SIZE> LineTraceArea::RIGHT_COURSE_INFO
-    = { SectionParam{ 1625.340, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 594.506, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 690.288, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 511.724, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 1709.700, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 309.562, 20, 30, PidGain(0.8, 0.01, 0.01) },
-        SectionParam{ 807.404, 20, 30, PidGain(0.8, 0.01, 0.01) } };
+    = { SectionParam{ 150, 12, 60, PidGain(0.1, 0.8, 0.1) },
+        SectionParam{ 1445, 12, 100, PidGain(3.5, 1, 1) },
+        SectionParam{ 670, 12, 55, PidGain(1, 0.8, 1) },
+        SectionParam{ 600, 12, 100, PidGain(3, 2.7, 1.2) },
+        SectionParam{ 580, 12, 60, PidGain(0.9, 0.3, 0.6) },
+        SectionParam{ 1450, 12, 100, PidGain(2, 0.9, 0.9) },
+        SectionParam{ 400, 12, 50, PidGain(5, 0.8, 0.9) },
+        SectionParam{ 1000, 12, 100, PidGain(3, 1, 0.8) } };
 
 void LineTraceArea::runLineTraceArea()
 {

--- a/module/LineTraceArea.h
+++ b/module/LineTraceArea.h
@@ -37,7 +37,7 @@ class LineTraceArea {
   static void runLineTraceArea();
 
  private:
-  static const int LEFT_SECTION_SIZE = 7;   // Lコースの区間の数
+  static const int LEFT_SECTION_SIZE = 8;   // Lコースの区間の数
   static const int RIGHT_SECTION_SIZE = 7;  // Rコースの区間の数
   static const std::array<SectionParam, LEFT_SECTION_SIZE> LEFT_COURSE_INFO;  // Lコースの情報
   static const std::array<SectionParam, RIGHT_SECTION_SIZE> RIGHT_COURSE_INFO;  // Rコースの情報

--- a/module/LineTraceArea.h
+++ b/module/LineTraceArea.h
@@ -38,7 +38,7 @@ class LineTraceArea {
 
  private:
   static const int LEFT_SECTION_SIZE = 8;   // Lコースの区間の数
-  static const int RIGHT_SECTION_SIZE = 7;  // Rコースの区間の数
+  static const int RIGHT_SECTION_SIZE = 8;  // Rコースの区間の数
   static const std::array<SectionParam, LEFT_SECTION_SIZE> LEFT_COURSE_INFO;  // Lコースの情報
   static const std::array<SectionParam, RIGHT_SECTION_SIZE> RIGHT_COURSE_INFO;  // Rコースの情報
 


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
LineTraceArea.hのLRコースのサイズを変更
LineTraceArea.cppのLRコースのPIDパラメータを調整、区間の距離を変更

# 動作テスト
https://user-images.githubusercontent.com/83002406/123203629-9fe93600-d4f1-11eb-9209-197c85288dbf.mp4

https://user-images.githubusercontent.com/66076307/123535494-13dc4600-d75f-11eb-9a21-f2462072ca5a.mp4


## 実験方法
全体の明るさ、影の方向、Lコーススポットライト、Rコーススポットライトの明るさをそれぞれ最小(0)、最大(3)にして（16パターン）各条件で10回ずつ走らせる（計160回）

Lコース初期位置
　X:3.53, Y:0, Z:-16.52, ROT:90
Rコース初期位置
　X:-3.53, Y:0, Z:-16.52, ROT:-90
## 実験結果

Lコース
・**平均タイム:18.486(s)(n=154)**
・**走破率:96.250(%)(n=160)**
備考:6/160のコースアウトが見られた、スタートやゴール前カーブで回転し始めて進まないケースや、ゴール前直線でのコースアウトであった


Rコース
・**平均タイム:18.507(s)(n=156)**
・**走破率:97.500(%)(n=160)**
備考:4/160のコースアウトが見られた、コースアウトしたケースはすべてゴール前直線でコースアウトしていた

LRコース
・***平均走破率:96.875(%)***
・タイムは割愛
備考:ターミナル上のタイムよりシミュレータ上のタイムが少し早くなっているので実際のタイムはもう少し早いと考えられます(0.2sくらい？)

## 添付資料
[result_l.txt](https://github.com/KatLab-MiyazakiUniv/etrobocon2021/files/6721138/result_l.txt)
[result_r.txt](https://github.com/KatLab-MiyazakiUniv/etrobocon2021/files/6721013/result_r.txt)
回転し始めるパターン

https://user-images.githubusercontent.com/66076307/123590894-47ce6e80-d826-11eb-8298-f90807f255d2.mp4


