### PR TITLE
close #61 白黒以外を判定するまでライントレースする

### DIFF
--- a/module/LineTracer.h
+++ b/module/LineTracer.h
@@ -11,6 +11,7 @@
 #include "Measurer.h"
 #include "Mileage.h"
 #include "Controller.h"
+#include "ColorJudge.h"
 
 /**
  * ライントレースをするクラス
@@ -31,6 +32,14 @@ class LineTracer {
    * @param gain PIDを保持する構造体
    */
   void run(double targetDistance, int targetBrightness, int pwm, const PidGain& gain);
+
+  /**
+   * 白黒を判定している間ライントレースをする関数
+   * @param targetBrightness 目標輝度
+   * @param pwm PWM値
+   * @param gain PIDを保持する構造体
+   */
+  void runToColor(int targetBrightness, int pwm, const PidGain& gain);
 
  private:
   bool isLeftEdge;


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- LineTracerクラスに、白黒を識別している間、ライントレースするrunByColor()を追加
- 「色を取得・識別する」がないため、コンパイル・テストは通らない。(あれば通った)

# 動作テスト

## 実験方法
- 「色を取得・識別する」を反映し、テストした
- ライントレースエリア(ゴール付近の青線まで)を3回ライントレースした
- ブロックビンゴエリアにて、ライン上の各色(黄、赤、青、緑)について、10回ずつライントレースした

## 実験結果
- ライントレースで、ライントレースエリアを完走できた。
- いずれも、白黒以外の色に入った時点で停止した。

## 添付資料

https://user-images.githubusercontent.com/83441177/123540592-c79eff00-d77a-11eb-8896-dddcf6edbe22.mp4

