### PR TITLE
close #67 直進・後退する

### DIFF
--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -17,8 +17,8 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
   // 初期値を格納
   initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
 
-  // pwm値が0の際は、終了する
-  if(pwm == 0) return;
+  // 距離の値が0または、pwm値が0の際は、終了する
+  if(targetDistance < 0 || pwm == 0) return;
 
   // 走行距離が目標距離に到達するまで繰り返す
   while(true) {

--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file StraightRunner.cpp
+ * @brief 直進クラス
+ * @author hiroto0927, miyashita64
+ */
+
+#include "StraightRunner.h"
+
+StraightRunner::StraightRunner() {}
+
+// 設定された距離を直進する
+void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
+{
+  double initialDistance = 0;
+  double currentDistance = 0;
+
+  // 初期値を格納
+  initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+
+  // 走行距離が目標距離に到達するまで繰り返す
+  while(true) {
+    currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+    if(std::abs(currentDistance - initialDistance) >= targetDistance) {
+      break;
+    }
+    // モータのPWM値をセット
+    controller.setRightMotorPwm(pwm);
+    controller.setLeftMotorPwm(pwm);
+    // 10ミリ秒待機
+    controller.sleep();
+  }
+  // モータの停止
+  controller.stopMotor();
+}
+
+// 白黒以外の色を検出するまで直進する
+void StraightRunner::runStraightToColor(int pwm)
+{
+  while(true) {
+    // 現在のRGB値から色を識別する
+    COLOR color = ColorJudge::getColor(measurer.getRawColor());
+
+    // 白黒以外の色を検出した場合、直進終了
+    if(color != COLOR::BLACK && color != COLOR::WHITE) {
+      break;
+    }
+
+    // モータのPWM値をセット
+    controller.setRightMotorPwm(pwm);
+    controller.setLeftMotorPwm(pwm);
+    // 10ミリ秒待機
+    controller.sleep();
+  }
+  // モータの停止
+  controller.stopMotor();
+}

--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -17,9 +17,15 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
   // 初期値を格納
   initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
 
+  // pwm値が0の際は、終了する
+  if(pwm == 0) return;
+
   // 走行距離が目標距離に到達するまで繰り返す
   while(true) {
+    //現在の距離を取得する
     currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+
+    //現在の距離が目標距離に到達したらループを終了する
     if(std::abs(currentDistance - initialDistance) >= targetDistance) {
       break;
     }
@@ -36,6 +42,9 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
 // 白黒以外の色を検出するまで直進する
 void StraightRunner::runStraightToColor(int pwm)
 {
+  // pwm値が0の際は、終了する。
+  if(pwm == 0) return;
+
   while(true) {
     // 現在のRGB値から色を識別する
     COLOR color = ColorJudge::getColor(measurer.getRawColor());

--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -17,7 +17,7 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
   // 初期値を格納
   initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
 
-  // 距離の値が0または、pwm値が0の際は、終了する
+  // 距離の値が負または、pwm値が0の際は、終了する
   if(targetDistance < 0 || pwm == 0) return;
 
   // 走行距離が目標距離に到達するまで繰り返す

--- a/module/StraightRunner.h
+++ b/module/StraightRunner.h
@@ -1,0 +1,39 @@
+/**
+ * @file StraightRunner.h
+ * @brief 直進クラス
+ * @author hiroto0927, miyashita64
+ */
+
+#ifndef STRAIGHTER_H
+#define STRAIGHTER_H
+
+#include "Measurer.h"
+#include "Mileage.h"
+#include "Controller.h"
+#include "ColorJudge.h"
+
+class StraightRunner {
+ public:
+  /**
+   * コンストラクタ
+   */
+  StraightRunner();
+
+  /**
+   * 指定された距離を直進する関数
+   * @param targetDistance 目標距離
+   * @param pwm PWM値
+   */
+  void runStraightToDistance(double targetDistance, int pwm);
+
+  /**
+   * 白黒以外の色を検出するまで直進する関数
+   * @param pwm PWM値
+   */
+  void runStraightToColor(int pwm);
+
+ private:
+  Measurer measurer;
+  Controller controller;
+};
+#endif

--- a/test/StraightRunnerTest.cpp
+++ b/test/StraightRunnerTest.cpp
@@ -1,0 +1,191 @@
+/**
+ * @file   StraightRunnerTest.cpp
+ * @brief  StraightRunnerクラスのテストファイル
+ * @author hiroto0927, miyashita64
+ */
+
+#include <gtest/gtest.h>
+#include "Controller.h"
+#include "Measurer.h"
+#include "StraightRunner.h"
+
+using namespace std;
+
+namespace etrobocon2021_test {
+
+  TEST(runStraightToDistanceTest, runStraightToDistance)
+  {
+    Measurer measurer;
+    StraightRunner straightRunner;
+    double expectedDistance, currentDistance;
+    double leftAngle, rightAngle;
+    double leftInitial, rightInitial;
+    double leftActual, rightActual;
+    double leftDifference, rightDifference;
+
+    double targetDistance = 350;
+    int pwm = 50;
+    double distanceError = 1.5, differenceError = 0.8;
+
+    // 初期値
+    rightAngle = measurer.getRightCount();
+    leftAngle = measurer.getLeftCount();
+    leftInitial = Mileage::calculateWheelMileage(leftAngle);
+    rightInitial = Mileage::calculateWheelMileage(rightAngle);
+    // 期待する走行距離
+    expectedDistance = Mileage::calculateMileage(rightAngle, leftAngle) + targetDistance;
+    // 直進
+    straightRunner.runStraightToDistance(targetDistance, pwm);
+    // 関数実行後の走行距離
+    leftAngle = measurer.getLeftCount();
+    rightAngle = measurer.getRightCount();
+    leftActual = Mileage::calculateWheelMileage(leftAngle);
+    rightActual = Mileage::calculateWheelMileage(rightAngle);
+    currentDistance = Mileage::calculateMileage(rightAngle, leftAngle);
+    // 左右の進行距離
+    leftDifference = std::abs(leftActual - leftInitial);
+    rightDifference = std::abs(rightActual - rightInitial);
+    // 走行距離のテスト
+    EXPECT_LE(expectedDistance, currentDistance);
+    EXPECT_GE(expectedDistance + distanceError, currentDistance);
+    // 直進できているかのテスト
+    EXPECT_GE(differenceError, std::abs(leftDifference - rightDifference));
+  }
+
+  TEST(runStraightToDistanceTest, runStraightToDistanceFullPwm)
+  {
+    Measurer measurer;
+    StraightRunner straightRunner;
+    double expectedDistance, currentDistance;
+    double leftAngle, rightAngle;
+    double leftInitial, rightInitial;
+    double leftActual, rightActual;
+    double leftDifference, rightDifference;
+
+    double targetDistance = 350;
+    int pwm = 100;
+    double distanceError = 3.5, differenceError = 0.8;
+
+    // 初期値
+    leftAngle = measurer.getLeftCount();
+    rightAngle = measurer.getRightCount();
+    leftInitial = Mileage::calculateWheelMileage(leftAngle);
+    rightInitial = Mileage::calculateWheelMileage(rightAngle);
+    // 期待する走行距離
+    expectedDistance = Mileage::calculateMileage(rightAngle, leftAngle) + targetDistance;
+    // 直進
+    straightRunner.runStraightToDistance(targetDistance, pwm);
+    // 関数実行後の走行距離
+    leftAngle = measurer.getLeftCount();
+    rightAngle = measurer.getRightCount();
+    leftActual = Mileage::calculateWheelMileage(leftAngle);
+    rightActual = Mileage::calculateWheelMileage(rightAngle);
+    currentDistance = Mileage::calculateMileage(rightAngle, leftAngle);
+    // 左右の進行距離
+    leftDifference = std::abs(leftActual - leftInitial);
+    rightDifference = std::abs(rightActual - rightInitial);
+    // 走行距離のテスト
+    EXPECT_LE(expectedDistance, currentDistance);
+    EXPECT_GE(expectedDistance + distanceError, currentDistance);
+    // 直進できているかのテスト
+    EXPECT_GE(differenceError, std::abs(leftDifference - rightDifference));
+  }
+
+  TEST(runStraightToDistanceTest, runStraightToDistanceZero)
+  {
+    Measurer measurer;
+    StraightRunner straightRunner;
+    double expectedDistance, currentDistance;
+
+    double targetDistance = 0;
+    int pwm = 100;
+
+    // 期待する走行距離
+    expectedDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount())
+                       + targetDistance;
+    // 直進
+    straightRunner.runStraightToDistance(targetDistance, pwm);
+    // 関数実行後の走行距離
+    currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+    // 走行距離のテスト
+    EXPECT_EQ(expectedDistance, currentDistance);
+  }
+
+  TEST(runStraightToDistanceTest, runStraightToDistanceMinusPwm)
+  {
+    Measurer measurer;
+    StraightRunner straightRunner;
+    double expectedDistance, currentDistance;
+    double leftAngle, rightAngle;
+    double leftInitial, rightInitial;
+    double leftActual, rightActual;
+    double leftDifference, rightDifference;
+
+    double targetDistance = 350;
+    int pwm = -50;
+    double distanceError = 1.5, differenceError = 0.8;
+
+    // 初期値
+    leftAngle = measurer.getLeftCount();
+    rightAngle = measurer.getRightCount();
+    leftInitial = Mileage::calculateWheelMileage(leftAngle);
+    rightInitial = Mileage::calculateWheelMileage(rightAngle);
+    // 期待する走行距離
+    expectedDistance = Mileage::calculateMileage(rightAngle, leftAngle) - targetDistance;
+    // 直進
+    straightRunner.runStraightToDistance(targetDistance, pwm);
+    // 関数実行後の走行距離
+    leftAngle = measurer.getLeftCount();
+    rightAngle = measurer.getRightCount();
+    leftActual = Mileage::calculateWheelMileage(leftAngle);
+    rightActual = Mileage::calculateWheelMileage(rightAngle);
+    currentDistance = Mileage::calculateMileage(rightAngle, leftAngle);
+    // 左右の進行距離
+    leftDifference = std::abs(leftActual - leftInitial);
+    rightDifference = std::abs(rightActual - rightInitial);
+    // 走行距離のテスト
+    EXPECT_GE(expectedDistance, currentDistance);
+    EXPECT_LE(expectedDistance - distanceError, currentDistance);
+    // 直進できているかのテスト
+    EXPECT_GE(differenceError, std::abs(leftDifference - rightDifference));
+  }
+
+  TEST(runStraightToDistanceTest, runStraightToDistanceMinusFullPwm)
+  {
+    Measurer measurer;
+    StraightRunner straightRunner;
+    double expectedDistance, currentDistance;
+    double leftAngle, rightAngle;
+    double leftInitial, rightInitial;
+    double leftActual, rightActual;
+    double leftDifference, rightDifference;
+
+    double targetDistance = 350;
+    int pwm = -100;
+    double distanceError = 3.5, differenceError = 0.8;
+
+    // 初期値
+    leftAngle = measurer.getLeftCount();
+    rightAngle = measurer.getRightCount();
+    leftInitial = Mileage::calculateWheelMileage(leftAngle);
+    rightInitial = Mileage::calculateWheelMileage(rightAngle);
+    // 期待する走行距離
+    expectedDistance = Mileage::calculateMileage(rightAngle, leftAngle) - targetDistance;
+    // 直進
+    straightRunner.runStraightToDistance(targetDistance, pwm);
+    // 関数実行後の走行距離
+    leftAngle = measurer.getLeftCount();
+    rightAngle = measurer.getRightCount();
+    leftActual = Mileage::calculateWheelMileage(leftAngle);
+    rightActual = Mileage::calculateWheelMileage(rightAngle);
+    currentDistance = Mileage::calculateMileage(rightAngle, leftAngle);
+    // 左右の進行距離
+    leftDifference = std::abs(leftActual - leftInitial);
+    rightDifference = std::abs(rightActual - rightInitial);
+    // 走行距離のテスト
+    EXPECT_GE(expectedDistance, currentDistance);
+    EXPECT_LE(expectedDistance - distanceError, currentDistance);
+    // 直進できているかのテスト
+    EXPECT_GE(differenceError, std::abs(leftDifference - rightDifference));
+  }
+}  // namespace etrobocon2021_test

--- a/test/StraightRunnerTest.cpp
+++ b/test/StraightRunnerTest.cpp
@@ -1,7 +1,7 @@
 /**
- * @file   StraightRunnerTest.cpp
- * @brief  StraightRunnerクラスのテストファイル
- * @author hiroto0927, miyashita64
+ *  @file   StraightRunnerTest.cpp
+ *  @brief  StraightRunnerクラスのテストファイル
+ *  @author mutotaka0426
  */
 
 #include <gtest/gtest.h>
@@ -187,5 +187,43 @@ namespace etrobocon2021_test {
     EXPECT_LE(expectedDistance - distanceError, currentDistance);
     // 直進できているかのテスト
     EXPECT_GE(differenceError, std::abs(leftDifference - rightDifference));
+  }
+
+  TEST(runStraightToDistanceTest, runStraightToDistancePwmZero)
+  {
+    Measurer measurer;
+    StraightRunner straightRunner;
+    double expectedDistance, currentDistance;
+
+    double targetDistance = 350;
+    int pwm = 0;
+
+    // 期待する走行距離
+    expectedDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+    // 直進
+    straightRunner.runStraightToDistance(targetDistance, pwm);
+    // 関数実行後の走行距離
+    currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+    // 走行距離のテスト
+    EXPECT_EQ(expectedDistance, currentDistance);
+  }
+
+  TEST(runStraightToDistanceTest, runStraightToMinusDistancePwmZero)
+  {
+    Measurer measurer;
+    StraightRunner straightRunner;
+    double expectedDistance, currentDistance;
+
+    double targetDistance = -350;
+    int pwm = 0;
+
+    // 期待する走行距離
+    expectedDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+    // 直進
+    straightRunner.runStraightToDistance(targetDistance, pwm);
+    // 関数実行後の走行距離
+    currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+    // 走行距離のテスト
+    EXPECT_EQ(expectedDistance, currentDistance);
   }
 }  // namespace etrobocon2021_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
直進・後退するクラス（Straighter）を作成。
指定距離を直進・後退する関数(straight())を作成。
白黒以外を検知するまで直進・後退する関数(straightByColor())を作成。

# 動作テスト


## 実験方法
ブロックビンゴエリアに走行体を設置し、走行体が色を認識するまで直進（後退）させる。
指定した距離（1050mm）を直進（後退）する。

## 実験結果
白黒以外の色を認識すると走行体が止まった（直進と後退）

指定した距離（1050mm）を進んだ（直進と後退）
ただし、多少右へのずれあり。

## 添付資料

https://user-images.githubusercontent.com/83230897/123544256-60d71100-d78d-11eb-9f3c-4cd3cbf95d34.mp4

https://user-images.githubusercontent.com/83230897/123544251-5ddc2080-d78d-11eb-9e19-02f629e5d938.mp4

https://user-images.githubusercontent.com/83230897/123545555-8f57ea80-d793-11eb-983e-549197b5bf9b.mp4

https://user-images.githubusercontent.com/83230897/123545845-23768180-d795-11eb-99e0-02d3baa48d06.mp4
