### PR TITLE
close #99 シミュレータが起動しない問題の解決

### DIFF
--- a/module/BlockSelector.cpp
+++ b/module/BlockSelector.cpp
@@ -11,7 +11,28 @@ BlockSelector::BlockSelector(BingoArea& _bingoArea, DestinationList& _destinatio
   : bingoArea(_bingoArea),
     destinationList(_destination),
     arrivableBlocks{ T, F, T, T, T, F, F, F },
-    arrivableCircles{ T, T, F, T, F, F, F, F }
+    arrivableCircles{ T, T, F, T, F, F, F, F },
+    OPEN_CIRCLE_ID{ {
+        { T, T, T, T, F, F, F, F },
+        { F, T, T, F, T, F, F, F },
+        { T, T, F, T, F, T, F, F },
+        { T, T, T, T, T, F, T, T },
+        { T, T, F, T, T, T, T, T },
+        { F, F, T, F, T, F, T, T },
+        { F, F, F, T, F, T, T, F },
+        { F, F, F, F, T, T, T, T },
+    } },
+    OPEN_BLOCK_ID{ {
+        { T, T, T, T, T, F, F, F },
+        { T, T, F, T, F, T, F, F },
+        { T, F, T, T, T, F, T, F },
+        { T, T, T, T, T, T, F, T },
+        { T, F, T, T, T, T, T, T },
+        { F, T, F, T, T, T, F, T },
+        { F, F, T, F, T, F, T, T },
+        { F, F, F, T, T, T, T, T },
+    } }
+
 {
 }
 

--- a/module/BlockSelector.h
+++ b/module/BlockSelector.h
@@ -38,33 +38,9 @@ class BlockSelector {
   std::array<bool, static_cast<int>(CIRCLE_ID::ID7) + 1> arrivableCircles;
 
   // ブロックがなくなった際、到着可能になるサークル
-  const std::array<std::array<bool, static_cast<int>(CIRCLE_ID::ID7) + 1>,
-                   static_cast<int>(BLOCK_ID::ID7) + 1>
-      // ブロックが運搬された際に開放されるブロックサークル
-      OPEN_CIRCLE_ID = { {
-          { T, T, T, T, F, F, F, F },
-          { F, T, T, F, T, F, F, F },
-          { T, T, F, T, F, T, F, F },
-          { T, T, T, T, T, F, T, T },
-          { T, T, F, T, T, T, T, T },
-          { F, F, T, F, T, F, T, T },
-          { F, F, F, T, F, T, T, F },
-          { F, F, F, F, T, T, T, T },
-      } };
+  const std::array<std::array<bool, static_cast<int>(BLOCK_ID::ID7) + 1>, 8> OPEN_CIRCLE_ID;
   // ブロックが運搬された際に開放されるブロック
-  const std::array<std::array<bool, static_cast<int>(BLOCK_ID::ID7) + 1>,
-                   static_cast<int>(BLOCK_ID::ID7) + 1>
-      // ブロックが運搬された際に開放されるブロック
-      OPEN_BLOCK_ID = { {
-          { T, T, T, T, T, F, F, F },
-          { T, T, F, T, F, T, F, F },
-          { T, F, T, T, T, F, T, F },
-          { T, T, T, T, T, T, F, T },
-          { T, F, T, T, T, T, T, T },
-          { F, T, F, T, T, T, F, T },
-          { F, F, T, F, T, F, T, T },
-          { F, F, F, T, T, T, T, T },
-      } };
+  const std::array<std::array<bool, 8>, 8> OPEN_BLOCK_ID;
 
   /**
    * ブロックが運搬済みかを判定する

--- a/module/BlockSelector.h
+++ b/module/BlockSelector.h
@@ -38,9 +38,13 @@ class BlockSelector {
   std::array<bool, static_cast<int>(CIRCLE_ID::ID7) + 1> arrivableCircles;
 
   // ブロックがなくなった際、到着可能になるサークル
-  const std::array<std::array<bool, static_cast<int>(BLOCK_ID::ID7) + 1>, 8> OPEN_CIRCLE_ID;
+  const std::array<std::array<bool, static_cast<int>(BLOCK_ID::ID7) + 1>,
+                   static_cast<int>(BLOCK_ID::ID7) + 1>
+      OPEN_CIRCLE_ID;
   // ブロックが運搬された際に開放されるブロック
-  const std::array<std::array<bool, 8>, 8> OPEN_BLOCK_ID;
+  const std::array<std::array<bool, static_cast<int>(BLOCK_ID::ID7) + 1>,
+                   static_cast<int>(BLOCK_ID::ID7) + 1>
+      OPEN_BLOCK_ID;
 
   /**
    * ブロックが運搬済みかを判定する

--- a/module/BlockSelector.h
+++ b/module/BlockSelector.h
@@ -37,8 +37,8 @@ class BlockSelector {
   // 走行体がブロックを運びうるサークル
   std::array<bool, static_cast<int>(CIRCLE_ID::ID7) + 1> arrivableCircles;
 
-  // ブロックがなくなった際、到着可能になるサークル
-  const std::array<std::array<bool, static_cast<int>(BLOCK_ID::ID7) + 1>,
+  // ブロックがなくなった際に到着可能になるサークル
+  const std::array<std::array<bool, static_cast<int>(CIRCLE_ID::ID7) + 1>,
                    static_cast<int>(BLOCK_ID::ID7) + 1>
       OPEN_CIRCLE_ID;
   // ブロックが運搬された際に開放されるブロック


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- BlockSelectorクラスのメンバにある配列の初期化をコンストラクタで行うように変更

# エラーの原因調査
```
  bool OPEN_CIRCLE_ID[static_cast<int>(BLOCK_ID::ID7) + 1][static_cast<int>(CIRCLE_ID::ID7) + 1] = {
          { T, T, T, T, F, F, F, F },
          { F, T, T, F, T, F, F, F },
          { T, T, F, T, F, T, F, F },
          { T, T, T, T, T, F, T, T },
          { T, T, F, T, T, T, T, T },
          { F, F, T, F, T, F, T, T },
          { F, F, F, T, F, T, T, F },
          { F, F, F, F, T, T, T, T }};
```
のように書き換えると解決したらしいので，STLコンテナが何か悪さをしている？

BlockSelectorクラスと同様に，宣言時に配列の初期化をするサンプルコードで試したところ，特にエラーは出なかったため，シミュレータ環境下での問題だと考えられる．
サンプルコードは下図に示す．

![キャプチャ](https://user-images.githubusercontent.com/56989154/126007117-683d6e00-6b53-4f65-b21a-84eade003481.PNG)

## 添付資料
