### PR TITLE
close #96 直進の精度調整

### DIFF
--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -41,11 +41,12 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
       break;
     }
 
+    printf("%d\n", currentPwm);
     // PWM値を徐々に目標値に合わせる
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
       currentPwm
-          = (currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM) * ((pwm > 0) ? 1 : -1);
+          = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM * ((pwm > 0) ? 1 : -1);
       if(std::abs(currentPwm) > std::abs(pwm)) {
         currentPwm = pwm;
       }
@@ -105,7 +106,7 @@ void StraightRunner::runStraightToColor(int pwm)
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
       currentPwm
-          = (currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM) * ((pwm > 0) ? 1 : -1);
+          = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM * ((pwm > 0) ? 1 : -1);
       if(std::abs(currentPwm) > std::abs(pwm)) {
         currentPwm = pwm;
       }
@@ -165,7 +166,7 @@ void StraightRunner::runStraightToBlackWhite(int pwm)
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
       currentPwm
-          = (currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM) * ((pwm > 0) ? 1 : -1);
+          = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM * ((pwm > 0) ? 1 : -1);
       if(std::abs(currentPwm) > std::abs(pwm)) {
         currentPwm = pwm;
       }

--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -41,7 +41,6 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
       break;
     }
 
-    printf("%d\n", currentPwm);
     // PWM値を徐々に目標値に合わせる
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく

--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -12,12 +12,12 @@ StraightRunner::StraightRunner() {}
 void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
 {
   // 直進前の走行距離
-  int initialRightDistance = measurer.getRightCount();
-  int initialLeftDistance = measurer.getLeftCount();
-  double initialDistance = Mileage::calculateMileage(initialRightDistance, initialLeftDistance);
+  int initialRightMotorCount = measurer.getRightCount();
+  int initialLeftMotorCount = measurer.getLeftCount();
+  double initialDistance = Mileage::calculateMileage(initialRightMotorCount, initialLeftMotorCount);
   // 直進中の走行距離
-  int currentRightDistance = 0;
-  int currentLeftDistance = 0;
+  int currentRightMotorCount = 0;
+  int currentLeftMotorCount = 0;
   double currentDistance = 0;
   int error = 0;                // 左右の回転数の誤差
   Pid pid(1.2, 0.3, 0.001, 0);  // 左右の回転数を合わせるためのPID
@@ -32,9 +32,9 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
   // 走行距離が目標距離に到達するまで繰り返す
   while(true) {
     //現在の距離を取得する
-    currentRightDistance = measurer.getRightCount();
-    currentLeftDistance = measurer.getLeftCount();
-    currentDistance = Mileage::calculateMileage(currentLeftDistance, currentRightDistance);
+    currentRightMotorCount = measurer.getRightCount();
+    currentLeftMotorCount = measurer.getLeftCount();
+    currentDistance = Mileage::calculateMileage(currentLeftMotorCount, currentRightMotorCount);
 
     //現在の距離が目標距離に到達したらループを終了する
     if(std::abs(currentDistance - initialDistance) >= targetDistance) {
@@ -44,15 +44,15 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
     // PWM値を徐々に目標値に合わせる
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
-      currentPwm = (currentDistance + SECTION_DISTANCE) / SECTION_DISTANCE * ACCELE_PWM;
+      currentPwm = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM;
       if(currentPwm > pwm) {
         currentPwm = pwm;
       }
     }
 
-    // 左右の走行距離を合わせるた補正値計算
-    error = (currentLeftDistance - initialLeftDistance)
-            - (currentRightDistance - initialRightDistance);
+    // 左右のモーターカウントを合わせるための補正値計算
+    error = (currentLeftMotorCount - initialLeftMotorCount)
+            - (currentRightMotorCount - initialRightMotorCount);
     adjustment = static_cast<int>(pid.calculatePid(error));
 
     // モータのPWM値をセット
@@ -70,11 +70,11 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
 void StraightRunner::runStraightToColor(int pwm)
 {
   // 直進前の走行距離
-  int initialRightDistance = measurer.getRightCount();
-  int initialLeftDistance = measurer.getLeftCount();
+  int initialRightMotorCount = measurer.getRightCount();
+  int initialLeftMotorCount = measurer.getLeftCount();
   // 直進中の走行距離
-  int currentRightDistance = 0;
-  int currentLeftDistance = 0;
+  int currentRightMotorCount = 0;
+  int currentLeftMotorCount = 0;
   int currentDistance = 0;
   int error = 0;                // 左右の回転数の誤差
   Pid pid(1.2, 0.3, 0.001, 0);  // 左右の回転数を合わせるためのPID
@@ -96,22 +96,22 @@ void StraightRunner::runStraightToColor(int pwm)
     }
 
     //現在の距離を取得する
-    currentRightDistance = measurer.getRightCount();
-    currentLeftDistance = measurer.getLeftCount();
-    currentDistance = Mileage::calculateMileage(currentLeftDistance, currentRightDistance);
+    currentRightMotorCount = measurer.getRightCount();
+    currentLeftMotorCount = measurer.getLeftCount();
+    currentDistance = Mileage::calculateMileage(currentLeftMotorCount, currentRightMotorCount);
 
     // PWM値を徐々に目標値に合わせる
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
-      currentPwm = (currentDistance + SECTION_DISTANCE) / SECTION_DISTANCE * ACCELE_PWM;
+      currentPwm = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM;
       if(currentPwm > pwm) {
         currentPwm = pwm;
       }
     }
 
-    // 左右の走行距離を合わせるた補正値計算
-    error = (currentLeftDistance - initialLeftDistance)
-            - (currentRightDistance - initialRightDistance);
+    // 左右のモーターカウントを合わせるための補正値計算
+    error = (currentLeftMotorCount - initialLeftMotorCount)
+            - (currentRightMotorCount - initialRightMotorCount);
     adjustment = static_cast<int>(pid.calculatePid(error));
 
     // モータのPWM値をセット
@@ -129,11 +129,11 @@ void StraightRunner::runStraightToColor(int pwm)
 void StraightRunner::runStraightToBlackWhite(int pwm)
 {
   // 直進前の走行距離
-  int initialRightDistance = measurer.getRightCount();
-  int initialLeftDistance = measurer.getLeftCount();
+  int initialRightMotorCount = measurer.getRightCount();
+  int initialLeftMotorCount = measurer.getLeftCount();
   // 直進中の走行距離
-  int currentRightDistance = 0;
-  int currentLeftDistance = 0;
+  int currentRightMotorCount = 0;
+  int currentLeftMotorCount = 0;
   int currentDistance = 0;
   int error = 0;                // 左右の回転数の誤差
   Pid pid(1.2, 0.3, 0.001, 0);  // 左右の回転数を合わせるためのPID
@@ -155,22 +155,22 @@ void StraightRunner::runStraightToBlackWhite(int pwm)
     }
 
     //現在の距離を取得する
-    currentRightDistance = measurer.getRightCount();
-    currentLeftDistance = measurer.getLeftCount();
-    currentDistance = Mileage::calculateMileage(currentLeftDistance, currentRightDistance);
+    currentRightMotorCount = measurer.getRightCount();
+    currentLeftMotorCount = measurer.getLeftCount();
+    currentDistance = Mileage::calculateMileage(currentLeftMotorCount, currentRightMotorCount);
 
     // PWM値を徐々に目標値に合わせる
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
-      currentPwm = (currentDistance + SECTION_DISTANCE) / SECTION_DISTANCE * ACCELE_PWM;
+      currentPwm = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM;
       if(currentPwm > pwm) {
         currentPwm = pwm;
       }
     }
 
-    // 左右の走行距離を合わせるた補正値計算
-    error = (currentLeftDistance - initialLeftDistance)
-            - (currentRightDistance - initialRightDistance);
+    // 左右のモーターカウントを合わせるための補正値計算
+    error = (currentLeftMotorCount - initialLeftMotorCount)
+            - (currentRightMotorCount - initialRightMotorCount);
     adjustment = static_cast<int>(pid.calculatePid(error));
 
     // モータのPWM値をセット

--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -11,11 +11,20 @@ StraightRunner::StraightRunner() {}
 // 設定された距離を直進する
 void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
 {
-  double initialDistance = 0;
+  // 直進前の走行距離
+  int initialRightDistance = measurer.getRightCount();
+  int initialLeftDistance = measurer.getLeftCount();
+  double initialDistance = Mileage::calculateMileage(initialRightDistance, initialLeftDistance);
+  // 直進中の走行距離
+  int currentRightDistance = 0;
+  int currentLeftDistance = 0;
   double currentDistance = 0;
+  int error = 0;                // 左右の回転数の誤差
+  Pid pid(1.2, 0.3, 0.001, 0);  // 左右の回転数を合わせるためのPID
+  int adjustment = 0;           // 左右の誤差の補正値
 
-  // 初期値を格納
-  initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+  // 現在のpwm値
+  int currentPwm = 0;
 
   // 距離の値が負または、pwm値が0の際は、終了する
   if(targetDistance < 0 || pwm == 0) return;
@@ -23,15 +32,33 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
   // 走行距離が目標距離に到達するまで繰り返す
   while(true) {
     //現在の距離を取得する
-    currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
+    currentRightDistance = measurer.getRightCount();
+    currentLeftDistance = measurer.getLeftCount();
+    currentDistance = Mileage::calculateMileage(currentLeftDistance, currentRightDistance);
 
     //現在の距離が目標距離に到達したらループを終了する
     if(std::abs(currentDistance - initialDistance) >= targetDistance) {
       break;
     }
+
+    // PWM値を徐々に目標値に合わせる
+    if(currentPwm != pwm) {
+      // 調整距離毎にPWM値を加速値分だけ上げていく
+      currentPwm = (currentDistance + SECTION_DISTANCE) / SECTION_DISTANCE * ACCELE_PWM;
+      if(currentPwm > pwm) {
+        currentPwm = pwm;
+      }
+    }
+
+    // 左右の走行距離を合わせるた補正値計算
+    error = (currentLeftDistance - initialLeftDistance)
+            - (currentRightDistance - initialRightDistance);
+    adjustment = static_cast<int>(pid.calculatePid(error));
+
     // モータのPWM値をセット
-    controller.setRightMotorPwm(pwm);
-    controller.setLeftMotorPwm(pwm);
+    controller.setLeftMotorPwm(currentPwm + adjustment);
+    controller.setRightMotorPwm(currentPwm - adjustment);
+
     // 10ミリ秒待機
     controller.sleep();
   }
@@ -42,6 +69,20 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
 // 白黒以外の色を検出するまで直進する
 void StraightRunner::runStraightToColor(int pwm)
 {
+  // 直進前の走行距離
+  int initialRightDistance = measurer.getRightCount();
+  int initialLeftDistance = measurer.getLeftCount();
+  // 直進中の走行距離
+  int currentRightDistance = 0;
+  int currentLeftDistance = 0;
+  int currentDistance = 0;
+  int error = 0;                // 左右の回転数の誤差
+  Pid pid(1.2, 0.3, 0.001, 0);  // 左右の回転数を合わせるためのPID
+  int adjustment = 0;           // 左右の誤差の補正値
+
+  // 現在のpwm値
+  int currentPwm = 0;
+
   // pwm値が0の際は、終了する。
   if(pwm == 0) return;
 
@@ -54,9 +95,88 @@ void StraightRunner::runStraightToColor(int pwm)
       break;
     }
 
+    //現在の距離を取得する
+    currentRightDistance = measurer.getRightCount();
+    currentLeftDistance = measurer.getLeftCount();
+    currentDistance = Mileage::calculateMileage(currentLeftDistance, currentRightDistance);
+
+    // PWM値を徐々に目標値に合わせる
+    if(currentPwm != pwm) {
+      // 調整距離毎にPWM値を加速値分だけ上げていく
+      currentPwm = (currentDistance + SECTION_DISTANCE) / SECTION_DISTANCE * ACCELE_PWM;
+      if(currentPwm > pwm) {
+        currentPwm = pwm;
+      }
+    }
+
+    // 左右の走行距離を合わせるた補正値計算
+    error = (currentLeftDistance - initialLeftDistance)
+            - (currentRightDistance - initialRightDistance);
+    adjustment = static_cast<int>(pid.calculatePid(error));
+
     // モータのPWM値をセット
-    controller.setRightMotorPwm(pwm);
-    controller.setLeftMotorPwm(pwm);
+    controller.setLeftMotorPwm(currentPwm + adjustment);
+    controller.setRightMotorPwm(currentPwm - adjustment);
+
+    // 10ミリ秒待機
+    controller.sleep();
+  }
+  // モータの停止
+  controller.stopMotor();
+}
+
+// 白黒を検出するまで直進する
+void StraightRunner::runStraightToBlackWhite(int pwm)
+{
+  // 直進前の走行距離
+  int initialRightDistance = measurer.getRightCount();
+  int initialLeftDistance = measurer.getLeftCount();
+  // 直進中の走行距離
+  int currentRightDistance = 0;
+  int currentLeftDistance = 0;
+  int currentDistance = 0;
+  int error = 0;                // 左右の回転数の誤差
+  Pid pid(1.2, 0.3, 0.001, 0);  // 左右の回転数を合わせるためのPID
+  int adjustment = 0;           // 左右の誤差の補正値
+
+  // 現在のpwm値
+  int currentPwm = 0;
+
+  // pwm値が0の際は、終了する。
+  if(pwm == 0) return;
+
+  while(true) {
+    // 現在のRGB値から色を識別する
+    COLOR color = ColorJudge::getColor(measurer.getRawColor());
+
+    // 白黒を検出した場合、直進終了
+    if(color == COLOR::BLACK || color == COLOR::WHITE) {
+      break;
+    }
+
+    //現在の距離を取得する
+    currentRightDistance = measurer.getRightCount();
+    currentLeftDistance = measurer.getLeftCount();
+    currentDistance = Mileage::calculateMileage(currentLeftDistance, currentRightDistance);
+
+    // PWM値を徐々に目標値に合わせる
+    if(currentPwm != pwm) {
+      // 調整距離毎にPWM値を加速値分だけ上げていく
+      currentPwm = (currentDistance + SECTION_DISTANCE) / SECTION_DISTANCE * ACCELE_PWM;
+      if(currentPwm > pwm) {
+        currentPwm = pwm;
+      }
+    }
+
+    // 左右の走行距離を合わせるた補正値計算
+    error = (currentLeftDistance - initialLeftDistance)
+            - (currentRightDistance - initialRightDistance);
+    adjustment = static_cast<int>(pid.calculatePid(error));
+
+    // モータのPWM値をセット
+    controller.setLeftMotorPwm(currentPwm + adjustment);
+    controller.setRightMotorPwm(currentPwm - adjustment);
+
     // 10ミリ秒待機
     controller.sleep();
   }

--- a/module/StraightRunner.cpp
+++ b/module/StraightRunner.cpp
@@ -44,8 +44,9 @@ void StraightRunner::runStraightToDistance(double targetDistance, int pwm)
     // PWM値を徐々に目標値に合わせる
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
-      currentPwm = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM;
-      if(currentPwm > pwm) {
+      currentPwm
+          = (currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM) * ((pwm > 0) ? 1 : -1);
+      if(std::abs(currentPwm) > std::abs(pwm)) {
         currentPwm = pwm;
       }
     }
@@ -103,8 +104,9 @@ void StraightRunner::runStraightToColor(int pwm)
     // PWM値を徐々に目標値に合わせる
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
-      currentPwm = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM;
-      if(currentPwm > pwm) {
+      currentPwm
+          = (currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM) * ((pwm > 0) ? 1 : -1);
+      if(std::abs(currentPwm) > std::abs(pwm)) {
         currentPwm = pwm;
       }
     }
@@ -162,8 +164,9 @@ void StraightRunner::runStraightToBlackWhite(int pwm)
     // PWM値を徐々に目標値に合わせる
     if(currentPwm != pwm) {
       // 調整距離毎にPWM値を加速値分だけ上げていく
-      currentPwm = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM;
-      if(currentPwm > pwm) {
+      currentPwm
+          = (currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM) * ((pwm > 0) ? 1 : -1);
+      if(std::abs(currentPwm) > std::abs(pwm)) {
         currentPwm = pwm;
       }
     }

--- a/module/StraightRunner.h
+++ b/module/StraightRunner.h
@@ -41,7 +41,7 @@ class StraightRunner {
 
  private:
   // SECTION_DISTANCE毎にACCELE_PWMだけPWM値を上げる
-  static constexpr int SECTION_DISTANCE = 10;  // 調整距離
+  static constexpr int SECTION_DISTANCE = 10;  // 調整距離[mm]
   static constexpr int ACCELE_PWM = 10;        // 追加のPWM値
 
   Measurer measurer;

--- a/module/StraightRunner.h
+++ b/module/StraightRunner.h
@@ -11,6 +11,7 @@
 #include "Mileage.h"
 #include "Controller.h"
 #include "ColorJudge.h"
+#include "Pid.h"
 
 class StraightRunner {
  public:
@@ -32,7 +33,17 @@ class StraightRunner {
    */
   void runStraightToColor(int pwm);
 
+  /**
+   * 白黒を検出するまで直進する関数
+   * @param pwm PWM値
+   */
+  void runStraightToBlackWhite(int pwm);
+
  private:
+  // SECTION_DISTANCE毎にACCELE_PWMだけPWM値を上げる
+  static constexpr int SECTION_DISTANCE = 10;  // 調整距離
+  static constexpr int ACCELE_PWM = 5;         // 追加のPWM値
+
   Measurer measurer;
   Controller controller;
 };

--- a/module/StraightRunner.h
+++ b/module/StraightRunner.h
@@ -42,7 +42,7 @@ class StraightRunner {
  private:
   // SECTION_DISTANCE毎にACCELE_PWMだけPWM値を上げる
   static constexpr int SECTION_DISTANCE = 10;  // 調整距離
-  static constexpr int ACCELE_PWM = 5;         // 追加のPWM値
+  static constexpr int ACCELE_PWM = 10;        // 追加のPWM値
 
   Measurer measurer;
   Controller controller;


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
StraightRunnerクラス
- 黒白を検知するまで直進するメンバ関数を追加
- 各メンバ関数に、左右のモータカウントを合わせる処理を追加
- 各メンバ関数に、指定値に向けて、徐々に加速する処理を追加

# 動作テスト
## 実験方法
一定距離(ビンゴのマスの辺2.5本分)をPWM値、50, 100でそれぞれ10回走行し、黒線と比べ、どれだけずれているかを見る。
真上から見た際の、黒線との角度の差(deg)を計測した。

## 実験結果
PWM=50 誤差単位[deg]
| 修正前 | 修正後 |
| ------------- | ------------- |
| 3.0 | 1.4 |
| 3.5 | 2.1  |
| 2.0| 1.1 |
| 2.0| 2.1  |
| 4.6  | 0.3  |
| 4.0  | 2.3  |
| 0.0  | 0.5  |
| 2.8  | 1.0  |
| 1.4  | 0.8  |
| 1.0  | 0.2  |

修正前平均：2.43 deg
修正後平均：1.18 deg

PWM=100 誤差単位[deg]
| 修正前 | 修正後 |
| ------------- | ------------- |
| 4.5  | 2.2 |
| 39.2 | 4.2 |
| 3.5 | 2.6 |
| 13.2 | 0.5 |
| 7.6 | 1.3 |
| 34.1 | 2.3 |
| 25.2 | 1.0 |
| 5.5 | 1.2 |
| 19.8 | 1.3 |
| 47.8 | 1.3 |

修正前平均：20.04 deg
修正後平均：1.79 deg

PWM=50のとき
修正前

https://user-images.githubusercontent.com/83441177/126912123-0606cb19-30c5-4b23-8cb0-dae8bbf46567.mp4

修正後

https://user-images.githubusercontent.com/83441177/126912118-7808bc50-0d86-4dbd-b5c6-aef6a0e0461d.mp4

修正後(ブロック運搬)

https://user-images.githubusercontent.com/83441177/127014375-b4a6aec8-3a31-47d1-adb8-8dbdf2511b8a.mp4

PWM=100のとき
修正前

https://user-images.githubusercontent.com/83441177/126912140-59afac86-4544-4c98-a635-1b39798f14be.mp4

修正後

https://user-images.githubusercontent.com/83441177/126912178-96888987-39e1-4ea6-8967-05af134a553f.mp4


https://user-images.githubusercontent.com/83441177/126912182-dd6c7484-5e5c-4013-b701-c8044dc36b34.mp4

PWM=-50のとき

修正後

https://user-images.githubusercontent.com/83441177/127431742-16173df6-a07a-4776-bfd3-6397c2968847.mp4



## 添付資料