### PR TITLE
close #97 回頭・ピボットターンの精度調整

### DIFF
--- a/module/Rotation.cpp
+++ b/module/Rotation.cpp
@@ -14,30 +14,31 @@ void Rotation::rotateLeft(int angle, int pwm)
 {
   int leftSign = -1;
   int rightSign = 1;
-  double currentLeftDistance = 0;
   double currentRightDistance = 0;
   double targetDistance = M_PI * TREAD * abs(angle) / 360;  //弧の長さ
   //目標距離（呼び出し時の走行距離 ± 指定された回転量に必要な距離）
-  double targetLeftDistance
-      = Mileage::calculateWheelMileage(measurer.getLeftCount()) - targetDistance;
   double targetRightDistance
       = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
+  int ratePwm;  // タイヤのモーターパワー(回頭角度に応じて減衰していく)
+  double countRate;  //現在のタイヤの回転比率[0.0~1.0]
+  double baseDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
 
   //両輪が目標距離に到達するまでループ
   while(leftSign != 0 || rightSign != 0) {
     //現在の走行距離を取得
-    currentLeftDistance = Mileage::calculateWheelMileage(measurer.getLeftCount());
     currentRightDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
     //目標距離に到達したらpwm値にかける値を0にする
-    if(currentLeftDistance <= targetLeftDistance) {
-      leftSign = 0;
-    }
     if(currentRightDistance >= targetRightDistance) {
+      leftSign = 0;
       rightSign = 0;
     }
+    //目標距離に近づくほどPWM値が下がる。（最低値が５）
+    countRate = 1 - (currentRightDistance - baseDistance) / targetDistance;
+    ratePwm = pwm * countRate > 5 ? (pwm * countRate) : 5;
+
     //モータのPWM値をセット
-    controller.setLeftMotorPwm(abs(pwm) * leftSign);
-    controller.setRightMotorPwm(abs(pwm) * rightSign);
+    controller.setLeftMotorPwm(abs(ratePwm) * leftSign);
+    controller.setRightMotorPwm(abs(ratePwm) * rightSign);
 
     // 10ミリ秒待機
     controller.sleep();
@@ -52,29 +53,31 @@ void Rotation::rotateRight(int angle, int pwm)
   int leftSign = 1;
   int rightSign = -1;
   double currentLeftDistance = 0;
-  double currentRightDistance = 0;
   double targetDistance = M_PI * TREAD * abs(angle) / 360;  //弧の長さ
   //左右のタイヤの目標距離
   double targetLeftDistance
       = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
-  double targetRightDistance
-      = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
+  int ratePwm;  // タイヤのモーターパワー(回頭角度に応じて減衰していく)
+  double countRate;  //現在のタイヤの回転比率[0.0~1.0]
+  double baseDistance = Mileage::calculateWheelMileage(measurer.getLeftCount());
 
   //両輪が目標距離に到達するまでループ
   while(leftSign != 0 || rightSign != 0) {
     //現在の走行距離を取得
     currentLeftDistance = Mileage::calculateWheelMileage(measurer.getLeftCount());
-    currentRightDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
+
     //目標距離に到達したらpwm値にかける値を0にする
     if(currentLeftDistance >= targetLeftDistance) {
       leftSign = 0;
-    }
-    if(currentRightDistance <= targetRightDistance) {
       rightSign = 0;
     }
+
+    countRate = 1 - (currentLeftDistance - baseDistance) / targetDistance;
+    ratePwm = pwm * countRate > 5 ? (pwm * countRate) : 5;
+
     //モータのPWM値をセット
-    controller.setLeftMotorPwm(abs(pwm) * leftSign);
-    controller.setRightMotorPwm(abs(pwm) * rightSign);
+    controller.setLeftMotorPwm(abs(ratePwm) * leftSign);
+    controller.setRightMotorPwm(abs(ratePwm) * rightSign);
 
     // 10ミリ秒待機
     controller.sleep();
@@ -86,9 +89,11 @@ void Rotation::rotateRight(int angle, int pwm)
 //設定された角度とPWM値で右タイヤを軸に前方へピボットターンする
 void Rotation::turnForwardRightPivot(int angle, int pwm)
 {
-  double distance = 2 * M_PI * TREAD * angle / 360;  //弧の長さ
+  double distance = DIAMETER * M_PI * angle / 360;  //弧の長さ
   double targetDistance = Mileage::calculateWheelMileage(measurer.getLeftCount()) + distance;
-
+  int leftPwm;  // タイヤのモーターパワー(回頭角度に応じて減衰していく)
+  double leftCountRate;  //現在のタイヤの回転比率[0.0~1.0]
+  double baseDistance = Mileage::calculateWheelMileage(measurer.getLeftCount());
   //目標距離を超えるまでループ
   while(true) {
     //現在の距離を取得
@@ -98,9 +103,12 @@ void Rotation::turnForwardRightPivot(int angle, int pwm)
       break;
     }
 
+    leftCountRate = 1 - (currentDistance - baseDistance) / distance;
+    leftPwm = pwm * leftCountRate > 15 ? (pwm * leftCountRate) : 15;
+
     //モータのPWM値をセット
     controller.setRightMotorPwm(0);
-    controller.setLeftMotorPwm(pwm);
+    controller.setLeftMotorPwm(leftPwm);
 
     // 10ミリ秒待機
     controller.sleep();
@@ -112,9 +120,11 @@ void Rotation::turnForwardRightPivot(int angle, int pwm)
 //設定された角度とPWM値で右タイヤを軸に後方へピボットターンする
 void Rotation::turnBackRightPivot(int angle, int pwm)
 {
-  double distance = 2 * M_PI * TREAD * angle / 360;  //弧の長さ
+  double distance = (DIAMETER - 5) * M_PI * angle / 360;  //弧の長さ
   double targetDistance = Mileage::calculateWheelMileage(measurer.getLeftCount()) - distance;
-
+  int leftPwm;  // タイヤのモーターパワー(回頭角度に応じて減衰していく)
+  double leftCountRate;  //現在のタイヤの回転比率[0.0~1.0]
+  double baseDistance = Mileage::calculateWheelMileage(measurer.getLeftCount());
   //目標距離を超えるまでループ
   while(true) {
     double currentDistance = Mileage::calculateWheelMileage(measurer.getLeftCount());
@@ -123,9 +133,12 @@ void Rotation::turnBackRightPivot(int angle, int pwm)
       break;
     }
 
+    leftCountRate = 1 - (baseDistance - currentDistance) / distance;
+    leftPwm = pwm * leftCountRate > 10 ? (pwm * leftCountRate) : 10;
+
     //モータのPWM値をセット
     controller.setRightMotorPwm(0);
-    controller.setLeftMotorPwm(-pwm);
+    controller.setLeftMotorPwm(-leftPwm);
 
     // 10ミリ秒待機
     controller.sleep();
@@ -137,19 +150,22 @@ void Rotation::turnBackRightPivot(int angle, int pwm)
 //設定された角度とPWM値で左タイヤを軸に前方へピボットターンする
 void Rotation::turnForwardLeftPivot(int angle, int pwm)
 {
-  double distance = 2 * M_PI * TREAD * angle / 360;  //弧の長さ
+  double distance = DIAMETER * M_PI * angle / 360;  //弧の長さ
   double targetDistance = Mileage::calculateWheelMileage(measurer.getRightCount()) + distance;
-
+  int rightPwm;  // タイヤのモーターパワー(回頭角度に応じて減衰していく)
+  double rightCountRate;  //現在のタイヤの回転比率[0.0~1.0]
+  double baseDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
   //目標距離を超えるまでループ
   while(true) {
     double currentDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
 
-    if(currentDistance >= targetDistance) {
-      break;
-    }
+    if(currentDistance >= targetDistance) break;
+
+    rightCountRate = 1 - (currentDistance - baseDistance) / distance;
+    rightPwm = pwm * rightCountRate > 15 ? (pwm * rightCountRate) : 15;
 
     //モータのPWM値をセット
-    controller.setRightMotorPwm(pwm);
+    controller.setRightMotorPwm(rightPwm);
     controller.setLeftMotorPwm(0);
 
     // 10ミリ秒待機
@@ -162,9 +178,11 @@ void Rotation::turnForwardLeftPivot(int angle, int pwm)
 //設定された角度とPWM値で左タイヤを軸に後方へピボットターンする
 void Rotation::turnBackLeftPivot(int angle, int pwm)
 {
-  double distance = 2 * M_PI * TREAD * angle / 360;  //弧の長さ
+  double distance = (DIAMETER - 5) * M_PI * angle / 360;  //弧の長さ
   double targetDistance = Mileage::calculateWheelMileage(measurer.getRightCount()) - distance;
-
+  int rightPwm;  // タイヤのモーターパワー(回頭角度に応じて減衰していく)
+  double rightCountRate;  //現在のタイヤの回転比率[0.0~1.0]
+  double baseDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
   //目標距離を超えるまでループ
   while(true) {
     double currentDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
@@ -173,8 +191,11 @@ void Rotation::turnBackLeftPivot(int angle, int pwm)
       break;
     }
 
+    rightCountRate = 1 - (baseDistance - currentDistance) / distance;
+    rightPwm = pwm * rightCountRate > 10 ? (pwm * rightCountRate) : 10;
+
     //モータのPWM値をセット
-    controller.setRightMotorPwm(-pwm);
+    controller.setRightMotorPwm(-rightPwm);
     controller.setLeftMotorPwm(0);
 
     // 10ミリ秒待機

--- a/module/Rotation.h
+++ b/module/Rotation.h
@@ -63,8 +63,8 @@ class Rotation {
   Controller controller;
   Measurer measurer;
 
-  static constexpr double RADIUS = 45.0;
-  static constexpr double TREAD = 140.0;
+  static constexpr double TREAD = 135.0; //回頭の円の直径
+  static constexpr double DIAMETER = 310.0; //ピボットターンの円の直径
 };
 
 #endif

--- a/test/RotationTest.cpp
+++ b/test/RotationTest.cpp
@@ -21,7 +21,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 140.0;
+    double tread = 135.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -30,17 +30,13 @@ namespace etrobocon2021_test {
     pwm = 30;
     targetDistance = M_PI * tread * abs(angle) / 360;
     // 期待する走行距離
-    leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - targetDistance;
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
     // 回頭
     rotation.rotateLeft(angle, pwm);
     // 関数実行後の走行距離
-    leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
     rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
     // 誤差のテスト
-    EXPECT_GE(leftExpected, leftActual);
     EXPECT_LE(rightExpected, rightActual);
-    EXPECT_LE(leftExpected - error, leftActual);
     EXPECT_GE(rightExpected + error, rightActual);
 
     // 180度左回頭の回頭誤差が１度未満かテスト
@@ -48,17 +44,13 @@ namespace etrobocon2021_test {
     pwm = 30;
     targetDistance = M_PI * tread * abs(angle) / 360;
 
-    leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - targetDistance;
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
 
     rotation.rotateLeft(angle, pwm);
 
-    leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
     rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
-    EXPECT_GE(leftExpected, leftActual);
     EXPECT_LE(rightExpected, rightActual);
-    EXPECT_LE(leftExpected - error, leftActual);
     EXPECT_GE(rightExpected + error, rightActual);
 
     // 360度左回頭の回頭誤差が１度未満かテスト
@@ -66,17 +58,13 @@ namespace etrobocon2021_test {
     pwm = 30;
     targetDistance = M_PI * tread * abs(angle) / 360;
 
-    leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - targetDistance;
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
 
     rotation.rotateLeft(angle, pwm);
 
-    leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
     rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
-    EXPECT_GE(leftExpected, leftActual);
     EXPECT_LE(rightExpected, rightActual);
-    EXPECT_LE(leftExpected - error, leftActual);
     EXPECT_GE(rightExpected + error, rightActual);
   }
 
@@ -89,7 +77,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 140.0;
+    double tread = 135.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -98,15 +86,12 @@ namespace etrobocon2021_test {
     pwm = 30;
     targetDistance = M_PI * tread * abs(angle) / 360;
 
-    leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
-    rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
+    rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
 
     rotation.rotateLeft(angle, pwm);
 
-    leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
     rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
-    EXPECT_DOUBLE_EQ(leftExpected, leftActual);
     EXPECT_DOUBLE_EQ(rightExpected, rightActual);
   }
 
@@ -119,7 +104,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 140.0;
+    double tread = 135.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -128,17 +113,13 @@ namespace etrobocon2021_test {
     pwm = 100;
     targetDistance = M_PI * tread * abs(angle) / 360;
 
-    leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - targetDistance;
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
 
     rotation.rotateLeft(angle, pwm);
 
-    leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
     rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
-    EXPECT_GE(leftExpected, leftActual);
     EXPECT_LE(rightExpected, rightActual);
-    EXPECT_LE(leftExpected - error, leftActual);
     EXPECT_GE(rightExpected + error, rightActual);
   }
 
@@ -151,7 +132,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 140.0;
+    double tread = 135.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -160,17 +141,13 @@ namespace etrobocon2021_test {
     pwm = 100;
     targetDistance = M_PI * tread * abs(angle) / 360;
 
-    leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - targetDistance;
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
 
     rotation.rotateLeft(angle, pwm);
 
-    leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
     rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
-    EXPECT_GE(leftExpected, leftActual);
     EXPECT_LE(rightExpected, rightActual);
-    EXPECT_LE(leftExpected - error, leftActual);
     EXPECT_GE(rightExpected + error, rightActual);
 
     // PWM値がマイナス
@@ -178,17 +155,13 @@ namespace etrobocon2021_test {
     pwm = -100;
     targetDistance = M_PI * tread * abs(angle) / 360;
 
-    leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - targetDistance;
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
 
     rotation.rotateLeft(angle, pwm);
 
-    leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
     rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
-    EXPECT_GE(leftExpected, leftActual);
     EXPECT_LE(rightExpected, rightActual);
-    EXPECT_LE(leftExpected - error, leftActual);
     EXPECT_GE(rightExpected + error, rightActual);
   }
 
@@ -202,7 +175,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 140.0;
+    double tread = 135.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -212,17 +185,13 @@ namespace etrobocon2021_test {
     targetDistance = M_PI * tread * abs(angle) / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
-    rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
 
     rotation.rotateRight(angle, pwm);
 
     leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
-    rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
     EXPECT_LE(leftExpected, leftActual);
-    EXPECT_GE(rightExpected, rightActual);
     EXPECT_GE(leftExpected + error, leftActual);
-    EXPECT_LE(rightExpected - error, rightActual);
 
     // 180度右回頭の回頭誤差が１度未満かテスト
     angle = 180;
@@ -230,17 +199,13 @@ namespace etrobocon2021_test {
     targetDistance = M_PI * tread * abs(angle) / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
-    rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
 
     rotation.rotateRight(angle, pwm);
 
     leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
-    rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
     EXPECT_LE(leftExpected, leftActual);
-    EXPECT_GE(rightExpected, rightActual);
     EXPECT_GE(leftExpected + error, leftActual);
-    EXPECT_LE(rightExpected - error, rightActual);
   }
 
   TEST(Rotation, rotateRight_zero)
@@ -252,7 +217,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 140.0;
+    double tread = 135.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -262,15 +227,12 @@ namespace etrobocon2021_test {
     targetDistance = M_PI * tread * abs(angle) / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
-    rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
 
     rotation.rotateRight(angle, pwm);
 
     leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
-    rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
     EXPECT_DOUBLE_EQ(leftExpected, leftActual);
-    EXPECT_DOUBLE_EQ(rightExpected, rightActual);
   }
 
   TEST(Rotation, rotateRight_maxpwm)
@@ -282,7 +244,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 140.0;
+    double tread = 135.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -292,17 +254,13 @@ namespace etrobocon2021_test {
     targetDistance = M_PI * tread * abs(angle) / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
-    rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
 
     rotation.rotateRight(angle, pwm);
 
     leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
-    rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
     EXPECT_LE(leftExpected, leftActual);
-    EXPECT_GE(rightExpected, rightActual);
     EXPECT_GE(leftExpected + error, leftActual);
-    EXPECT_LE(rightExpected - error, rightActual);
   }
 
   TEST(Rotation, rotateRight_minus)
@@ -314,7 +272,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 140.0;
+    double tread = 135.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -324,17 +282,13 @@ namespace etrobocon2021_test {
     targetDistance = M_PI * tread * abs(angle) / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
-    rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
 
     rotation.rotateRight(angle, pwm);
 
     leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
-    rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
     EXPECT_LE(leftExpected, leftActual);
-    EXPECT_GE(rightExpected, rightActual);
     EXPECT_GE(leftExpected + error, leftActual);
-    EXPECT_LE(rightExpected - error, rightActual);
 
     // PWM値がマイナス
     angle = 90;
@@ -342,17 +296,13 @@ namespace etrobocon2021_test {
     targetDistance = M_PI * tread * abs(angle) / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
-    rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
 
     rotation.rotateRight(angle, pwm);
 
     leftActual = Mileage::calculateWheelMileage(measurer.getLeftCount());
-    rightActual = Mileage::calculateWheelMileage(measurer.getRightCount());
 
     EXPECT_LE(leftExpected, leftActual);
-    EXPECT_GE(rightExpected, rightActual);
     EXPECT_GE(leftExpected + error, leftActual);
-    EXPECT_LE(rightExpected - error, rightActual);
   }
 
   TEST(Rotation, turnForwardRightPivot)
@@ -363,14 +313,14 @@ namespace etrobocon2021_test {
     double leftActual;
     double leftMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 310.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // 90度右軸前方ピボットターン誤差が１度未満かテスト
     angle = 90;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + distance;
     // 右軸前方ピボットターン
@@ -384,7 +334,7 @@ namespace etrobocon2021_test {
     // 180度右軸前方ピボットターン誤差が１度未満かテスト
     angle = 180;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + distance;
     // 右軸前方ピボットターン
@@ -398,7 +348,7 @@ namespace etrobocon2021_test {
     // 360度右軸前方ピボットターン誤差が１度未満かテスト
     angle = 360;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + distance;
     // 右軸前方ピボットターン
@@ -418,14 +368,14 @@ namespace etrobocon2021_test {
     double leftActual;
     double leftMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 310.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // 0度右軸前方ピボットターンのテスト
     angle = 0;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + distance;
 
@@ -444,14 +394,14 @@ namespace etrobocon2021_test {
     double leftActual;
     double leftMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 310.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // PWM値が100の時のテスト
     angle = 90;
     pwm = 100;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) + distance;
 
@@ -471,14 +421,14 @@ namespace etrobocon2021_test {
     double leftActual;
     double leftMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 305.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // 90度右軸後方ピボットターン誤差が１度未満かテスト
     angle = 90;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - distance;
     // 右軸後方ピボットターン
@@ -492,7 +442,7 @@ namespace etrobocon2021_test {
     // 180度右軸後方ピボットターン誤差が１度未満かテスト
     angle = 180;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - distance;
     // 右軸後方ピボットターン
@@ -506,7 +456,7 @@ namespace etrobocon2021_test {
     // 360度右軸後方ピボットターン誤差が１度未満かテスト
     angle = 360;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - distance;
     // 右軸後方ピボットターン
@@ -526,14 +476,14 @@ namespace etrobocon2021_test {
     double leftActual;
     double leftMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 305.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // 0度右軸後方ピボットターンのテスト
     angle = 0;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - distance;
 
@@ -552,14 +502,14 @@ namespace etrobocon2021_test {
     double leftActual;
     double leftMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 305.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // PWM値が100の時のテスト
     angle = 90;
     pwm = 100;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
 
     leftExpected = Mileage::calculateWheelMileage(measurer.getLeftCount()) - distance;
 
@@ -579,14 +529,14 @@ namespace etrobocon2021_test {
     double rightActual;
     double rightMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 310.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // 90度左軸前方ピボットターン誤差が１度未満かテスト
     angle = 90;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + distance;
     // 左軸前方ピボットターン
@@ -600,7 +550,7 @@ namespace etrobocon2021_test {
     // 180度左軸前方ピボットターン誤差が１度未満かテスト
     angle = 180;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + distance;
     // 左軸前方ピボットターン
@@ -614,7 +564,7 @@ namespace etrobocon2021_test {
     // 360度左軸前方ピボットターン誤差が１度未満かテスト
     angle = 360;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + distance;
     // 左軸前方ピボットターン
@@ -634,14 +584,14 @@ namespace etrobocon2021_test {
     double rightActual;
     double rightMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 310.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // 0度左軸前方ピボットターンのテスト
     angle = 0;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
 
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + distance;
 
@@ -660,15 +610,15 @@ namespace etrobocon2021_test {
     double rightActual;
     double rightMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 310.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // PWM値が100の時のテスト
     //誤差2度未満
     angle = 90;
     pwm = 100;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
 
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) + distance;
 
@@ -688,14 +638,14 @@ namespace etrobocon2021_test {
     double rightActual;
     double rightMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 305.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // 90度左軸後方ピボットターン誤差が１度未満かテスト
     angle = 90;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - distance;
     // 左軸後方ピボットターン
@@ -709,7 +659,7 @@ namespace etrobocon2021_test {
     // 180度左軸後方ピボットターン誤差が１度未満かテスト
     angle = 180;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - distance;
     // 左軸後方ピボットターン
@@ -723,7 +673,7 @@ namespace etrobocon2021_test {
     // 360度左軸後方ピボットターン誤差が１度未満かテスト
     angle = 360;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
     // 期待する走行距離
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - distance;
     // 左軸後方ピボットターン
@@ -743,14 +693,14 @@ namespace etrobocon2021_test {
     double rightActual;
     double rightMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 305.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // 0度左軸後方ピボットターンのテスト
     angle = 0;
     pwm = 30;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
 
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - distance;
 
@@ -769,15 +719,15 @@ namespace etrobocon2021_test {
     double rightActual;
     double rightMotorCount;
     double distance;
-    double tread = 140.0;
-    double error = 2 * M_PI * tread / 360;  //誤差1度
+    double diameter = 305.0;
+    double error = M_PI * diameter / 360;  //誤差1度
     int angle, pwm;
 
     // PWM値が100の時のテスト
     //誤差2度未満
     angle = 90;
     pwm = 100;
-    distance = 2 * M_PI * tread * angle / 360;
+    distance = M_PI * diameter * angle / 360;
 
     rightExpected = Mileage::calculateWheelMileage(measurer.getRightCount()) - distance;
 

--- a/test/StraightRunnerTest.cpp
+++ b/test/StraightRunnerTest.cpp
@@ -25,7 +25,7 @@ namespace etrobocon2021_test {
 
     double targetDistance = 350;
     int pwm = 50;
-    double distanceError = 1.5, differenceError = 0.8;
+    double distanceError = 2.5, differenceError = 0.8;
 
     // 初期値
     rightAngle = measurer.getRightCount();


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- Rotation.cppの回頭とピボットターンに、目標値に近づくにつれPWM値を徐々に小さくしていく処理を追加
- 回頭での両方のタイヤを止める条件を片方の足に合わせた
- 回頭とピボットターンの描く円の直径を別々に定義した。回頭がTREAD、ピボットターンがDIAMETER。
# 動作テスト

https://user-images.githubusercontent.com/83375723/126997234-030a38ea-dc09-40e3-bde5-96b3efb82ad9.mp4


https://user-images.githubusercontent.com/83375723/126997736-eacbd46b-c906-4607-b78e-56fd01a0a349.mp4


https://user-images.githubusercontent.com/83375723/126997955-a9a421f5-5feb-4c81-91b6-1187091373f1.mp4


## 実験方法
- 回頭はPWM値40で４回動かした
- ピボットターン（前進）PWM値50で4回動かした
- ピボットターン（後進）PWM値50で4回動かした
## 実験結果
- PWM値をある程度限定すれば高い精度で回れると思う。
## 添付資料
