### PR TITLE
close #95 色識別の精度調整

### DIFF
--- a/module/ColorJudge.cpp
+++ b/module/ColorJudge.cpp
@@ -23,7 +23,7 @@ COLOR ColorJudge::getColor(rgb_raw_t const& _rgb)
   hsv = convertRgbToHsv(rgb);
 
   // RGBの中の最小値を求める
-  min = std::min({ _rgb.r, _rgb.g, _rgb.b });
+  min = std::min({ rgb.r, rgb.g, rgb.b });
 
   // 明度が極端に低ければ、黒を返す
   if(hsv.value < BLACK_LIMIT_BORDER) return COLOR::BLACK;

--- a/module/ColorJudge.h
+++ b/module/ColorJudge.h
@@ -36,17 +36,17 @@ class ColorJudge {
   static COLOR getColor(rgb_raw_t const& rgb);
 
  private:
-  static constexpr int SATURATION_BORDER = 12;  // 無彩色かの彩度の境界
+  static constexpr int SATURATION_BORDER = 15;  // 無彩色かの彩度の境界
 
   static constexpr int BLACK_LIMIT_BORDER = 80;   // 黒の明度の境界
-  static constexpr int WHITE_LIMIT_BORDER = 110;  // 白の明度の境界
+  static constexpr int WHITE_LIMIT_BORDER = 140;  // 白の明度の境界
   static constexpr int BLACK_BORDER = 110;        // 無彩色の黒の明度の境界
 
   static constexpr int RED_BORDER = 30;                    // 赤の色相の境界
   static constexpr int YELLOW_BORDER = 75;                 // 黄の色相の境界
-  static constexpr int GREEN_BORDER = 165;                 // 緑の色相の境界
+  static constexpr int GREEN_BORDER = 170;                 // 緑の色相の境界
   static constexpr int BLUE_BORDER = 300;                  // 青の色相の境界
-  static constexpr rgb_raw_t MAX_RGB = { 112, 107, 152 };  //コースが白の時（最大）のRGB値
+  static constexpr rgb_raw_t MAX_RGB = { 154, 143, 196 };  //コースが白の時（最大）のRGB値
   static constexpr rgb_raw_t MIN_RGB = { 4, 5, 8 };  //コースが黒の時（最小）のRGB値
   ColorJudge();
   static Hsv convertRgbToHsv(rgb_raw_t const& rgb);

--- a/module/ColorJudge.h
+++ b/module/ColorJudge.h
@@ -36,11 +36,11 @@ class ColorJudge {
   static COLOR getColor(rgb_raw_t const& rgb);
 
  private:
-  static constexpr int SATURATION_BORDER = 7;  // 無彩色かの彩度の境界
+  static constexpr int SATURATION_BORDER = 12;  // 無彩色かの彩度の境界
 
-  static constexpr int BLACK_LIMIT_BORDER = 50;  // 黒の明度の境界
-  static constexpr int WHITE_LIMIT_BORDER = 90;  // 白の明度の境界
-  static constexpr int BLACK_BORDER = 100;       // 無彩色の黒の明度の境界
+  static constexpr int BLACK_LIMIT_BORDER = 80;   // 黒の明度の境界
+  static constexpr int WHITE_LIMIT_BORDER = 110;  // 白の明度の境界
+  static constexpr int BLACK_BORDER = 110;        // 無彩色の黒の明度の境界
 
   static constexpr int RED_BORDER = 30;                    // 赤の色相の境界
   static constexpr int YELLOW_BORDER = 75;                 // 黄の色相の境界

--- a/test/ColorJudgeTest.cpp
+++ b/test/ColorJudgeTest.cpp
@@ -50,7 +50,7 @@ namespace etrobocon2021_test {
 
   TEST(getColorTest, getColorLightRed2)
   {
-    rgb_raw_t rgb = { 103, 90, 128 };
+    rgb_raw_t rgb = { 101, 76, 107 };
     COLOR expected = COLOR::RED;
 
     EXPECT_EQ(expected, ColorJudge::getColor(rgb));


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
ColorJudge.hのしきい値を変更
ColorJudge.cppの処理を修正
ColorJudgeTest.cppから不適切なテストケースを削除

# 動作テスト

## 実験方法
- シミュレータ環境で、走行体を走らせ取得したRGB値をcsvをとして保存
- csvから、ブロックビンゴエリアのマップを再現(html)
- csvから、色を識別し、マップを再現
- マップを比較

## 実験結果
環境①
全体の明るさ: 最低
スポットライト：最低

測定値

![040](https://user-images.githubusercontent.com/83441177/127439814-329c8bd0-7a03-4e70-aa46-6ff3eb526f83.png)

精度調整前

![040_old](https://user-images.githubusercontent.com/83441177/127439841-2cae93ca-42c7-4e35-b7de-448841c52de2.png)

精度調整後

![040_new](https://user-images.githubusercontent.com/83441177/127439860-497f7cdc-fff6-4403-9237-b96e3b776590.png)

環境②
全体の明るさ: 最低
スポットライト：最高

測定値

![044](https://user-images.githubusercontent.com/83441177/127434491-8ece7077-4811-4e60-abeb-958d6d137f4a.png)

精度調整前

![044_old](https://user-images.githubusercontent.com/83441177/127434516-80958ec7-698f-4aa3-a7e1-53170a84066e.png)

精度調整後

![044_new](https://user-images.githubusercontent.com/83441177/127434533-6c3ce05e-fec2-4129-a6b3-354d5e94fab9.png)

環境③
全体の明るさ: 最高
スポットライト：最高

測定値

![444](https://user-images.githubusercontent.com/83441177/127434556-5fc51cc4-aed1-457d-bc2b-85b1a565d110.png)

精度調整前

![444_old](https://user-images.githubusercontent.com/83441177/127434572-7091f3a9-d632-4b5d-b2a4-74494cb80980.png)

精度調整後

![444_new](https://user-images.githubusercontent.com/83441177/127434591-061facc0-1ee7-41c4-8c13-34a8b2e82d55.png)

## 添付資料
