### PR TITLE
close #144 アーム水平からPIDの処理を排除

### DIFF
--- a/module/Motion/ArmMotion.cpp
+++ b/module/Motion/ArmMotion.cpp
@@ -13,7 +13,6 @@ void ArmMotion::keepArm()
 {
   Measurer measurer;
   Controller controller;
-  Pid pid(1.0, 0.3, 0.001, HORIZONTAL_ARM_COUNT);
 
   // アーム水平が有効な場合、アームを水平にする
   while(keepFlag) {
@@ -23,7 +22,7 @@ void ArmMotion::keepArm()
       break;
     }
     // アームの角度が目標値(水平)になるように、アームを動かす
-    controller.setArmMotorPwm(pid.calculatePid(currentCount));
+    controller.setArmMotorPwm(HORIZONTAL_ARM_COUNT - currentCount);
     controller.sleep();
   }
   controller.sleep();

--- a/module/Motion/ArmMotion.h
+++ b/module/Motion/ArmMotion.h
@@ -9,7 +9,6 @@
 
 #include "Measurer.h"
 #include "Controller.h"
-#include "Pid.h"
 
 class ArmMotion {
  public:


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- ArmMotion.h から Pid.h のインクルードを削除
- ArmMotion.cpp から、出力をPIDでなく、目標値との差で算出するように変更


## 実験結果

## 添付資料

https://user-images.githubusercontent.com/83441177/130080346-a1446656-efea-4832-92fc-9cd776d6ef28.mp4

