### PR TITLE
close #137 設置動作の改良

### DIFF
--- a/module/BingoMotion/BlockThrower.cpp
+++ b/module/BingoMotion/BlockThrower.cpp
@@ -14,8 +14,8 @@ void BlockThrower::setBlockThrow(bool isClockwise)
   int runPwm = 30;
   int angle = 45;
   int rotatePwm = 100;
-  int leftSign;
-  int rightSign;
+  int leftSign = isClockwise ? 1 : -1;
+  int rightSign = isClockwise ? -1 : 1;
   double diffLeftDistance;
   double diffRightDistance;
   int leftPwm;
@@ -30,96 +30,46 @@ void BlockThrower::setBlockThrow(bool isClockwise)
   // アームを水平にする処理を無効化
   ArmMotion::setKeepFlag(false);
   //回頭する
-  if(isClockwise) {
-    leftSign = 1;
-    rightSign = -1;
-    targetLeftDistance
-        = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance * leftSign;
-    targetRightDistance
-        = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance * rightSign;
+  targetLeftDistance
+      = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance * leftSign;
+  targetRightDistance
+      = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance * rightSign;
 
-    //両輪が目標距離に到達するまでループ
-    while(leftSign != 0 || rightSign != 0) {
-      // 残りの移動距離
-      diffLeftDistance
-          = (targetLeftDistance - Mileage::calculateWheelMileage(measurer.getLeftCount()))
-            * leftSign;
-      diffRightDistance
-          = (targetRightDistance - Mileage::calculateWheelMileage(measurer.getRightCount()))
-            * rightSign;
+  //両輪が目標距離に到達するまでループ
+  while(leftSign != 0 || rightSign != 0) {
+    // 残りの移動距離
+    diffLeftDistance
+        = (targetLeftDistance - Mileage::calculateWheelMileage(measurer.getLeftCount())) * leftSign;
+    diffRightDistance
+        = (targetRightDistance - Mileage::calculateWheelMileage(measurer.getRightCount()))
+          * rightSign;
 
-      // 目標距離に到達した場合
-      if(diffLeftDistance <= 0) {
-        leftSign = 0;
-      }
-      if(diffRightDistance <= 0) {
-        rightSign = 0;
-      }
-
-      // PWM値 = 残りの走行距離/走行距離 * 指定PWM値(最小値 MIN_PWM)
-      leftPwm = (diffLeftDistance / targetDistance * rotatePwm >= MIN_PWM)
-                    ? diffLeftDistance / targetDistance * rotatePwm
-                    : MIN_PWM;
-      rightPwm = (diffRightDistance / targetDistance * rotatePwm >= MIN_PWM)
-                     ? diffRightDistance / targetDistance * rotatePwm
-                     : MIN_PWM;
-      controller.setLeftMotorPwm(abs(leftPwm) * leftSign);
-      controller.setRightMotorPwm(abs(rightPwm) * rightSign);
-
-      //アームの動作
-      if(measurer.getArmMotorCount() >= 40) {
-        armPwm = 0;
-      }
-      controller.setArmMotorPwm(armPwm);
-
-      // 10ミリ秒待機
-      controller.sleep();
+    // 目標距離に到達した場合
+    if(diffLeftDistance <= 0) {
+      leftSign = 0;
     }
-  } else {
-    leftSign = -1;
-    rightSign = 1;
-    targetLeftDistance
-        = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance * leftSign;
-    targetRightDistance
-        = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance * rightSign;
-
-    //両輪が目標距離に到達するまでループ
-    while(leftSign != 0 || rightSign != 0) {
-      // 残りの移動距離
-      diffLeftDistance
-          = (targetLeftDistance - Mileage::calculateWheelMileage(measurer.getLeftCount()))
-            * leftSign;
-      diffRightDistance
-          = (targetRightDistance - Mileage::calculateWheelMileage(measurer.getRightCount()))
-            * rightSign;
-
-      // 目標距離に到達した場合
-      if(diffLeftDistance <= 0) {
-        leftSign = 0;
-      }
-      if(diffRightDistance <= 0) {
-        rightSign = 0;
-      }
-
-      // PWM値 = 残りの走行距離/走行距離 * 指定PWM値(最小値 MIN_PWM)
-      leftPwm = (diffLeftDistance / targetDistance * rotatePwm >= MIN_PWM)
-                    ? diffLeftDistance / targetDistance * rotatePwm
-                    : MIN_PWM;
-      rightPwm = (diffRightDistance / targetDistance * rotatePwm >= MIN_PWM)
-                     ? diffRightDistance / targetDistance * rotatePwm
-                     : MIN_PWM;
-      controller.setLeftMotorPwm(abs(leftPwm) * leftSign);
-      controller.setRightMotorPwm(abs(rightPwm) * rightSign);
-
-      //アームの動作
-      if(measurer.getArmMotorCount() >= 40) {
-        armPwm = 0;
-      }
-      controller.setArmMotorPwm(armPwm);
-
-      // 10ミリ秒待機
-      controller.sleep();
+    if(diffRightDistance <= 0) {
+      rightSign = 0;
     }
+
+    // PWM値 = 残りの走行距離/走行距離 * 指定PWM値(最小値 MIN_PWM)
+    leftPwm = (diffLeftDistance / targetDistance * rotatePwm >= MIN_PWM)
+                  ? diffLeftDistance / targetDistance * rotatePwm
+                  : MIN_PWM;
+    rightPwm = (diffRightDistance / targetDistance * rotatePwm >= MIN_PWM)
+                   ? diffRightDistance / targetDistance * rotatePwm
+                   : MIN_PWM;
+    controller.setLeftMotorPwm(abs(leftPwm) * leftSign);
+    controller.setRightMotorPwm(abs(rightPwm) * rightSign);
+
+    //アームの動作
+    if(measurer.getArmMotorCount() >= 40) {
+      armPwm = 0;
+    }
+    controller.setArmMotorPwm(armPwm);
+
+    // 10ミリ秒待機
+    controller.sleep();
   }
   // アームを水平にする処理を有効化
   ArmMotion::setKeepFlag(true);

--- a/module/BingoMotion/BlockThrower.cpp
+++ b/module/BingoMotion/BlockThrower.cpp
@@ -10,18 +10,89 @@ BlockThrower::BlockThrower() : BingoMotion(1, 1) {}
 
 void BlockThrower::setBlockThrow(bool isClockwise)
 {
-  double targetDistance = 105;
-  int runPwm = 20;
+  double runDistance = 105;
+  int runPwm = 30;
   int angle = 45;
-  int rotatePwm = 20;
+  int rotatePwm = 55;
+  int leftSign;
+  int rightSign;
+  double currentLeftDistance = 0;
+  double currentRightDistance = 0;
+  double targetDistance = M_PI * 140 * angle / 360;
+  double targetLeftDistance;
+  double targetRightDistance;
+  int armPwm = 80;
 
   //黒線の奥まで直進する
-  straightRunner.runStraightToDistance(targetDistance, runPwm);
+  straightRunner.runStraightToDistance(runDistance, runPwm);
+  // アームを水平にする処理を無効化
+  ArmMotion::setKeepFlag(false);
   //回頭する
   if(isClockwise) {
-    rotation.rotateRight(angle, rotatePwm);
+    leftSign = 1;
+    rightSign = -1;
+    targetLeftDistance = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance;
+    targetRightDistance = Mileage::calculateWheelMileage(measurer.getRightCount()) - targetDistance;
+
+    //両輪が目標距離に到達するまでループ
+    while(leftSign != 0 || rightSign != 0) {
+      //現在の走行距離を取得
+      currentLeftDistance = Mileage::calculateWheelMileage(measurer.getLeftCount());
+      currentRightDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
+      //目標距離に到達したらpwm値にかける値を0にする
+      if(currentLeftDistance >= targetLeftDistance) {
+        leftSign = 0;
+      }
+      if(currentRightDistance <= targetRightDistance) {
+        rightSign = 0;
+      }
+      //モータのPWM値をセット
+      controller.setLeftMotorPwm(rotatePwm * leftSign);
+      controller.setRightMotorPwm(rotatePwm * rightSign);
+
+      //アームを動かす
+      while(measurer.getArmMotorCount() >= 40) {
+        armPwm = 0;
+      }
+      controller.setArmMotorPwm(armPwm);
+
+      // 10ミリ秒待機
+      controller.sleep();
+    }
   } else {
-    rotation.rotateLeft(angle, rotatePwm);
+    leftSign = -1;
+    rightSign = 1;
+    targetLeftDistance = Mileage::calculateWheelMileage(measurer.getLeftCount()) - targetDistance;
+    targetRightDistance = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance;
+
+    //両輪が目標距離に到達するまでループ
+    while(leftSign != 0 || rightSign != 0) {
+      //現在の走行距離を取得
+      currentLeftDistance = Mileage::calculateWheelMileage(measurer.getLeftCount());
+      currentRightDistance = Mileage::calculateWheelMileage(measurer.getRightCount());
+      //目標距離に到達したらpwm値にかける値を0にする
+      if(currentLeftDistance <= targetLeftDistance) {
+        leftSign = 0;
+      }
+      if(currentRightDistance >= targetRightDistance) {
+        rightSign = 0;
+      }
+      //モータのPWM値をセット
+      controller.setLeftMotorPwm(rotatePwm * leftSign);
+      controller.setRightMotorPwm(rotatePwm * rightSign);
+
+      //アームを動かす
+      while(measurer.getArmMotorCount() >= 40) {
+        armPwm = 0;
+      }
+      controller.setArmMotorPwm(armPwm);
+
+      // 10ミリ秒待機
+      controller.sleep();
+    }
   }
-  ArmMotion::throwMotion();
+  // アームを水平にする処理を有効化
+  ArmMotion::setKeepFlag(true);
+  //モータの停止
+  controller.stopMotor();
 }

--- a/module/BingoMotion/BlockThrower.h
+++ b/module/BingoMotion/BlockThrower.h
@@ -29,6 +29,9 @@ class BlockThrower : public BingoMotion {
   Rotation rotation;
   Controller controller;
   Measurer measurer;
+
+  static constexpr double TREAD = 140;  // 走行体のトレッド幅（両輪の間の距離）[mm]
+  static constexpr int MIN_PWM = 10;    // モーターパワーの最小値
 };
 
 #endif

--- a/module/BingoMotion/BlockThrower.h
+++ b/module/BingoMotion/BlockThrower.h
@@ -8,7 +8,6 @@
 #define BLOCK_THROWER_H
 
 #include "StraightRunner.h"
-#include "Rotation.h"
 #include "Controller.h"
 #include "BingoMotion.h"
 #include "ArmMotion.h"
@@ -26,7 +25,6 @@ class BlockThrower : public BingoMotion {
 
  private:
   StraightRunner straightRunner;
-  Rotation rotation;
   Controller controller;
   Measurer measurer;
 

--- a/module/BingoMotion/ToCrossMotion.cpp
+++ b/module/BingoMotion/ToCrossMotion.cpp
@@ -14,7 +14,7 @@ void ToCrossMotion::runToCross(void)
 {
   int targetBrightness = 12;
   int pwm = 40;
-  PidGain gain(2, 1, 1);
+  PidGain gain(0, 0, 0);
   StraightRunner straightRunner;
 
   //白黒以外までライントレース

--- a/module/BingoMotion/ToCrossMotion.cpp
+++ b/module/BingoMotion/ToCrossMotion.cpp
@@ -14,7 +14,7 @@ void ToCrossMotion::runToCross(void)
 {
   int targetBrightness = 12;
   int pwm = 40;
-  PidGain gain(0, 0, 0);
+  PidGain gain(2, 1, 1);
   StraightRunner straightRunner;
 
   //白黒以外までライントレース

--- a/module/Motion/ArmMotion.cpp
+++ b/module/Motion/ArmMotion.cpp
@@ -18,12 +18,13 @@ void ArmMotion::keepArm()
   // アーム水平が有効な場合、アームを水平にする
   while(keepFlag) {
     int currentCount = measurer.getArmMotorCount();
+
     // 水平になったとき、ループを抜ける
     if(currentCount == HORIZONTAL_ARM_COUNT) {
       break;
     }
     // アームの角度が目標値(水平)になるように、アームを動かす
-    controller.setArmMotorPwm(pid.calculatePid(currentCount));
+    controller.setArmMotorPwm(HORIZONTAL_ARM_COUNT - currentCount);
     controller.sleep();
   }
   controller.sleep();
@@ -54,3 +55,9 @@ void ArmMotion::throwMotion(void)
   // アームを水平にする処理を有効化
   keepFlag = true;
 }
+
+// フラグのセット
+void ArmMotion::setKeepFlag(bool _keepFlag)
+{
+  keepFlag = _keepFlag;
+};

--- a/module/Motion/ArmMotion.cpp
+++ b/module/Motion/ArmMotion.cpp
@@ -17,7 +17,6 @@ void ArmMotion::keepArm()
   // アーム水平が有効な場合、アームを水平にする
   while(keepFlag) {
     int currentCount = measurer.getArmMotorCount();
-
     // 水平になったとき、ループを抜ける
     if(currentCount == HORIZONTAL_ARM_COUNT) {
       break;

--- a/module/Motion/ArmMotion.h
+++ b/module/Motion/ArmMotion.h
@@ -23,6 +23,12 @@ class ArmMotion {
    */
   static void throwMotion(void);
 
+  /**
+   * @brief フラグのセッター
+   * @param _keepFlag アームを水平に調整するかのフラグ
+   */
+  static void setKeepFlag(bool _keepFlag);
+
  private:
   // アームが水平なときの角位置
   static constexpr int HORIZONTAL_ARM_COUNT = -45;

--- a/test/dummy/Motor.cpp
+++ b/test/dummy/Motor.cpp
@@ -17,8 +17,10 @@ int Motor::getCount()
 {
   if(port == PORT_C) {
     return static_cast<int>(leftCount);
-  } else {
+  } else if (port == PORT_B) {
     return static_cast<int>(rightCount);
+  } else {
+    return static_cast<int>(armCount);
   }
 }
 
@@ -27,10 +29,13 @@ void Motor::setPWM(int pwm)
 {
   if(port == PORT_C) {
     leftCount += pwm * 0.05;
-  } else {
+  } else if(port == PORT_B) {
     rightCount += pwm * 0.05;
+  } else {
+    armCount += pwm * 0.05;
   }
 }
 
 double Motor::leftCount = 0.0;
 double Motor::rightCount = 0.0;
+double Motor::armCount = 0.0;

--- a/test/dummy/Motor.h
+++ b/test/dummy/Motor.h
@@ -44,6 +44,7 @@ namespace ev3api {
    private:
     static double leftCount;
     static double rightCount;
+    static double armCount;
     ePortM port;
   };
 }  // namespace ev3api


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- 投げ入れ設置クラスで回頭と投げる動作を同時に行うように変更した

# 動作テスト

## 実験方法
- 10回動かして動作時間・誤差（角度）・投げ入れの成功を確認する

## 実験データ

|  修正前  |  修正後  |
| ---- | ---- |
|  -  |  -  |
|  -  |  -  |

[動作時間と誤差](https://docs.google.com/spreadsheets/d/1Go2aX7Qr2n07WcpFk1I_oKR1XRqddYP3sxdA602SNZU/edit#gid=0)


## 実験結果
- 設置位置にばらつきはあるが、動作テストではすべてブロックサークル内に収まっていた。
- まれにピボットターンのような挙動をすることがあった。（原因究明中。動作環境の問題？手元で何度か動かしてみていただけると助かります。）


## 添付資料
投げ入れ右
https://user-images.githubusercontent.com/83354922/130746997-18ab0aa9-71c9-4aa9-b8ff-129a76f52ea9.mp4

投げ入れ左
https://user-images.githubusercontent.com/83354922/130747077-e06cdf89-d714-44d8-ae6c-8dbdbf761b62.mp4



