### PR TITLE
close #153 取得経路と運搬経路を合体

### DIFF
--- a/module/RoutePlanner/RoutePlanner.cpp
+++ b/module/RoutePlanner/RoutePlanner.cpp
@@ -40,7 +40,7 @@ std::vector<std::vector<std::pair<Coordinate, Direction>>> RoutePlanner::planBin
     for(const auto& i : toBlockRoute) {
       carryRoute[count].push_back(i);
     }
-    count++;
+
     // 走行体が運搬ブロックを取得したとして、走行体の情報を更新する
     robot.setCoordinate(toBlockRoute.back().first);
     robot.setDirection(toBlockRoute.back().second);
@@ -49,8 +49,8 @@ std::vector<std::vector<std::pair<Coordinate, Direction>>> RoutePlanner::planBin
     std::vector<std::pair<Coordinate, Direction>> toCircleRoute
         = routeCalculator.calculateRoute(carryBlockCoord, targetCircleCoord);
     //設置経路を運搬経路リストに追加する
-    for(const auto& i : toCircleRoute) {
-      carryRoute[count].push_back(i);
+    for(int i =1;i<toCircleRoute.size();i++) {
+      carryRoute[count].push_back(toCircleRoute[i]);
     }
     count++;
 

--- a/module/RoutePlanner/RoutePlanner.cpp
+++ b/module/RoutePlanner/RoutePlanner.cpp
@@ -15,7 +15,7 @@ RoutePlanner::RoutePlanner(CourseInfo& _courseInfo, const bool IS_LEFT_COURSE)
 // 経路計画を立てる
 std::vector<std::vector<std::pair<Coordinate, Direction>>> RoutePlanner::planBingoRoute()
 {
-  std::vector<std::vector<std::pair<Coordinate, Direction>>> carryRoute(16);  //運搬経路リスト
+  std::vector<std::vector<std::pair<Coordinate, Direction>>> carryRoute(8);  //運搬経路リスト
   Robot robot(isLeftCourse);  // 経路計画用の仮想走行体インスタンス生成
   DestinationList destinationList(courseInfo);  // 運搬先を決定する
   BlockSelector blockSelector(courseInfo, destinationList, robot);

--- a/module/RoutePlanner/RoutePlanner.cpp
+++ b/module/RoutePlanner/RoutePlanner.cpp
@@ -49,7 +49,7 @@ std::vector<std::vector<std::pair<Coordinate, Direction>>> RoutePlanner::planBin
     std::vector<std::pair<Coordinate, Direction>> toCircleRoute
         = routeCalculator.calculateRoute(carryBlockCoord, targetCircleCoord);
     //設置経路を運搬経路リストに追加する
-    for(int i =1;i<toCircleRoute.size();i++) {
+    for(int i = 1; i < toCircleRoute.size(); i++) {
       carryRoute[count].push_back(toCircleRoute[i]);
     }
     count++;

--- a/test/RoutePlannerTest.cpp
+++ b/test/RoutePlannerTest.cpp
@@ -81,7 +81,7 @@ namespace etrobocon2021_test {
 
     std::vector<std::vector<std::pair<Coordinate, Direction>>> actual_route
         = routePlanner.planBingoRoute();
-    std::vector<std::vector<std::pair<Coordinate, Direction>>> expected_route(16);
+    std::vector<std::vector<std::pair<Coordinate, Direction>>> expected_route(8);
 
     // BLOCK_ID::3の緑ブロックまで移動する
     coordinate_start = { 2, 3 };
@@ -96,8 +96,8 @@ namespace etrobocon2021_test {
     // BLOCK_ID::3の緑ブロックをCIRCLE_ID::1の緑サークルまで移動させる
     coordinate_start = { 4, 2 };
     coordinate_goal = { 3, 1 };
-    expected_route[1].push_back(std::make_pair(coordinate_start, Direction::E));
-    expected_route[1].push_back(std::make_pair(coordinate_goal, Direction::NW));
+    // expected_route[0].push_back(std::make_pair(coordinate_start, Direction::E));
+    expected_route[0].push_back(std::make_pair(coordinate_goal, Direction::NW));
 
     // BLOCK_ID::0の黄ブロックまで移動する
     coordinate_start = { 4, 2 };
@@ -105,17 +105,15 @@ namespace etrobocon2021_test {
     route_2 = { 4, 0 };
     route_3 = { 3, 0 };
     coordinate_goal = { 2, 0 };
-    expected_route[2].push_back(std::make_pair(coordinate_start, Direction::E));
-    expected_route[2].push_back(std::make_pair(route_1, Direction::N));
-    expected_route[2].push_back(std::make_pair(route_2, Direction::N));
-    expected_route[2].push_back(std::make_pair(route_3, Direction::W));
-    expected_route[2].push_back(std::make_pair(coordinate_goal, Direction::W));
+    expected_route[1].push_back(std::make_pair(coordinate_start, Direction::E));
+    expected_route[1].push_back(std::make_pair(route_1, Direction::N));
+    expected_route[1].push_back(std::make_pair(route_2, Direction::N));
+    expected_route[1].push_back(std::make_pair(route_3, Direction::W));
+    expected_route[1].push_back(std::make_pair(coordinate_goal, Direction::W));
 
     // BLOCK_ID::0の黄ブロックをCIRCLE_ID::0の黄サークルまで移動させる
-    coordinate_start = { 2, 0 };
     coordinate_goal = { 1, 1 };
-    expected_route[3].push_back(std::make_pair(coordinate_start, Direction::W));
-    expected_route[3].push_back(std::make_pair(coordinate_goal, Direction::SW));
+    expected_route[1].push_back(std::make_pair(coordinate_goal, Direction::SW));
 
     // BLOCK_ID::4の黄ブロックまで移動する
     coordinate_start = { 2, 0 };
@@ -123,35 +121,31 @@ namespace etrobocon2021_test {
     route_2 = { 2, 2 };
     route_3 = { 2, 3 };
     coordinate_goal = { 2, 4 };
-    expected_route[4].push_back(std::make_pair(coordinate_start, Direction::SW));
-    expected_route[4].push_back(std::make_pair(route_1, Direction::S));
-    expected_route[4].push_back(std::make_pair(route_2, Direction::S));
-    expected_route[4].push_back(std::make_pair(route_3, Direction::S));
-    expected_route[4].push_back(std::make_pair(coordinate_goal, Direction::S));
+    expected_route[2].push_back(std::make_pair(coordinate_start, Direction::SW));
+    expected_route[2].push_back(std::make_pair(route_1, Direction::S));
+    expected_route[2].push_back(std::make_pair(route_2, Direction::S));
+    expected_route[2].push_back(std::make_pair(route_3, Direction::S));
+    expected_route[2].push_back(std::make_pair(coordinate_goal, Direction::S));
 
     // BLOCK_ID::4の黄ブロックをCIRCLE_ID::4の黄サークルまで移動させる
-    coordinate_start = { 2, 4 };
     route_1 = { 3, 4 };
     route_2 = { 4, 4 };
     coordinate_goal = { 5, 3 };
-    expected_route[5].push_back(std::make_pair(coordinate_start, Direction::S));
-    expected_route[5].push_back(std::make_pair(route_1, Direction::E));
-    expected_route[5].push_back(std::make_pair(route_2, Direction::E));
-    expected_route[5].push_back(std::make_pair(coordinate_goal, Direction::NE));
+    expected_route[2].push_back(std::make_pair(route_1, Direction::E));
+    expected_route[2].push_back(std::make_pair(route_2, Direction::E));
+    expected_route[2].push_back(std::make_pair(coordinate_goal, Direction::NE));
 
     // BLOCK_ID::7の青ブロックまで移動する
     coordinate_start = { 4, 4 };
     route_1 = { 4, 5 };
     coordinate_goal = { 4, 6 };
-    expected_route[6].push_back(std::make_pair(coordinate_start, Direction::NE));
-    expected_route[6].push_back(std::make_pair(route_1, Direction::S));
-    expected_route[6].push_back(std::make_pair(coordinate_goal, Direction::S));
+    expected_route[3].push_back(std::make_pair(coordinate_start, Direction::NE));
+    expected_route[3].push_back(std::make_pair(route_1, Direction::S));
+    expected_route[3].push_back(std::make_pair(coordinate_goal, Direction::S));
 
     // BLOCK_ID::7の青ブロックをCIRCLE_ID::7の青サークルまで移動させる
-    coordinate_start = { 4, 6 };
     coordinate_goal = { 5, 5 };
-    expected_route[7].push_back(std::make_pair(coordinate_start, Direction::S));
-    expected_route[7].push_back(std::make_pair(coordinate_goal, Direction::NE));
+    expected_route[3].push_back(std::make_pair(coordinate_goal, Direction::NE));
 
     // BLOCK_ID::6の緑ブロックまで移動する
     coordinate_start = { 4, 6 };
@@ -159,17 +153,15 @@ namespace etrobocon2021_test {
     route_2 = { 2, 6 };
     route_3 = { 1, 6 };
     coordinate_goal = { 0, 6 };
-    expected_route[8].push_back(std::make_pair(coordinate_start, Direction::S));
-    expected_route[8].push_back(std::make_pair(route_1, Direction::W));
-    expected_route[8].push_back(std::make_pair(route_2, Direction::W));
-    expected_route[8].push_back(std::make_pair(route_3, Direction::W));
-    expected_route[8].push_back(std::make_pair(coordinate_goal, Direction::W));
+    expected_route[4].push_back(std::make_pair(coordinate_start, Direction::S));
+    expected_route[4].push_back(std::make_pair(route_1, Direction::W));
+    expected_route[4].push_back(std::make_pair(route_2, Direction::W));
+    expected_route[4].push_back(std::make_pair(route_3, Direction::W));
+    expected_route[4].push_back(std::make_pair(coordinate_goal, Direction::W));
 
     // BLOCK_ID::6の緑ブロックをCIRCLE_ID::5の緑サークルまで移動させる
-    coordinate_start = { 0, 6 };
     coordinate_goal = { 1, 5 };
-    expected_route[9].push_back(std::make_pair(coordinate_start, Direction::W));
-    expected_route[9].push_back(std::make_pair(coordinate_goal, Direction::NE));
+    expected_route[4].push_back(std::make_pair(coordinate_goal, Direction::NE));
 
     // BLOCK_ID::2の赤ブロックまで移動する
     coordinate_start = { 0, 6 };
@@ -177,25 +169,23 @@ namespace etrobocon2021_test {
     route_2 = { 0, 4 };
     route_3 = { 0, 3 };
     coordinate_goal = { 0, 2 };
-    expected_route[10].push_back(std::make_pair(coordinate_start, Direction::W));
-    expected_route[10].push_back(std::make_pair(route_1, Direction::N));
-    expected_route[10].push_back(std::make_pair(route_2, Direction::N));
-    expected_route[10].push_back(std::make_pair(route_3, Direction::N));
-    expected_route[10].push_back(std::make_pair(coordinate_goal, Direction::N));
+    expected_route[5].push_back(std::make_pair(coordinate_start, Direction::W));
+    expected_route[5].push_back(std::make_pair(route_1, Direction::N));
+    expected_route[5].push_back(std::make_pair(route_2, Direction::N));
+    expected_route[5].push_back(std::make_pair(route_3, Direction::N));
+    expected_route[5].push_back(std::make_pair(coordinate_goal, Direction::N));
 
     // BLOCK_ID::2の赤ブロックをCIRCLE_ID::6の赤サークルまで移動させる
-    coordinate_start = { 0, 2 };
     route_1 = { 1, 2 };
     route_2 = { 2, 2 };
     route_3 = { 2, 3 };
     route_4 = { 2, 4 };
     coordinate_goal = { 3, 5 };
-    expected_route[11].push_back(std::make_pair(coordinate_start, Direction::N));
-    expected_route[11].push_back(std::make_pair(route_1, Direction::E));
-    expected_route[11].push_back(std::make_pair(route_2, Direction::E));
-    expected_route[11].push_back(std::make_pair(route_3, Direction::S));
-    expected_route[11].push_back(std::make_pair(route_4, Direction::S));
-    expected_route[11].push_back(std::make_pair(coordinate_goal, Direction::SE));
+    expected_route[5].push_back(std::make_pair(route_1, Direction::E));
+    expected_route[5].push_back(std::make_pair(route_2, Direction::E));
+    expected_route[5].push_back(std::make_pair(route_3, Direction::S));
+    expected_route[5].push_back(std::make_pair(route_4, Direction::S));
+    expected_route[5].push_back(std::make_pair(coordinate_goal, Direction::SE));
 
     // BLOCK_ID::5の赤ブロックまで移動する
     coordinate_start = { 2, 4 };
@@ -203,32 +193,29 @@ namespace etrobocon2021_test {
     route_2 = { 4, 4 };
     route_3 = { 5, 4 };
     coordinate_goal = { 6, 4 };
-    expected_route[12].push_back(std::make_pair(coordinate_start, Direction::SE));
-    expected_route[12].push_back(std::make_pair(route_1, Direction::E));
-    expected_route[12].push_back(std::make_pair(route_2, Direction::E));
-    expected_route[12].push_back(std::make_pair(route_3, Direction::E));
-    expected_route[12].push_back(std::make_pair(coordinate_goal, Direction::E));
+    expected_route[6].push_back(std::make_pair(coordinate_start, Direction::SE));
+    expected_route[6].push_back(std::make_pair(route_1, Direction::E));
+    expected_route[6].push_back(std::make_pair(route_2, Direction::E));
+    expected_route[6].push_back(std::make_pair(route_3, Direction::E));
+    expected_route[6].push_back(std::make_pair(coordinate_goal, Direction::E));
 
     // BLOCK_ID::5の赤ブロックをCIRCLE_ID::2の赤サークルまで移動させる
-    coordinate_start = { 6, 4 };
     route_1 = { 6, 3 };
     route_2 = { 6, 2 };
     coordinate_goal = { 5, 1 };
-    expected_route[13].push_back(std::make_pair(coordinate_start, Direction::E));
-    expected_route[13].push_back(std::make_pair(route_1, Direction::N));
-    expected_route[13].push_back(std::make_pair(route_2, Direction::N));
-    expected_route[13].push_back(std::make_pair(coordinate_goal, Direction::NW));
+    expected_route[6].push_back(std::make_pair(route_1, Direction::N));
+    expected_route[6].push_back(std::make_pair(route_2, Direction::N));
+    expected_route[6].push_back(std::make_pair(coordinate_goal, Direction::NW));
 
     // BLOCK_ID::1の青ブロックまで移動する
     coordinate_start = { 6, 2 };
     route_1 = { 6, 1 };
     coordinate_goal = { 6, 0 };
-    expected_route[14].push_back(std::make_pair(coordinate_start, Direction::NW));
-    expected_route[14].push_back(std::make_pair(route_1, Direction::N));
-    expected_route[14].push_back(std::make_pair(coordinate_goal, Direction::N));
+    expected_route[7].push_back(std::make_pair(coordinate_start, Direction::NW));
+    expected_route[7].push_back(std::make_pair(route_1, Direction::N));
+    expected_route[7].push_back(std::make_pair(coordinate_goal, Direction::N));
 
     // BLOCK_ID::1の青ブロックをCIRCLE_ID::3の青サークルまで移動させる
-    coordinate_start = { 6, 0 };
     route_1 = { 6, 1 };
     route_2 = { 6, 2 };
     route_3 = { 5, 2 };
@@ -236,14 +223,13 @@ namespace etrobocon2021_test {
     route_5 = { 3, 2 };
     route_6 = { 2, 2 };
     coordinate_goal = { 1, 3 };
-    expected_route[15].push_back(std::make_pair(coordinate_start, Direction::N));
-    expected_route[15].push_back(std::make_pair(route_1, Direction::S));
-    expected_route[15].push_back(std::make_pair(route_2, Direction::S));
-    expected_route[15].push_back(std::make_pair(route_3, Direction::W));
-    expected_route[15].push_back(std::make_pair(route_4, Direction::W));
-    expected_route[15].push_back(std::make_pair(route_5, Direction::W));
-    expected_route[15].push_back(std::make_pair(route_6, Direction::W));
-    expected_route[15].push_back(std::make_pair(coordinate_goal, Direction::SW));
+    expected_route[7].push_back(std::make_pair(route_1, Direction::S));
+    expected_route[7].push_back(std::make_pair(route_2, Direction::S));
+    expected_route[7].push_back(std::make_pair(route_3, Direction::W));
+    expected_route[7].push_back(std::make_pair(route_4, Direction::W));
+    expected_route[7].push_back(std::make_pair(route_5, Direction::W));
+    expected_route[7].push_back(std::make_pair(route_6, Direction::W));
+    expected_route[7].push_back(std::make_pair(coordinate_goal, Direction::SW));
 
     EXPECT_EQ(expected_route, actual_route);
   }


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- RoutePlannerにて、取得経路と運搬経路を合わせたものを1経路として保持するように変更
- 取得経路の末尾と設置経路の先頭が重複していたためfor文の添え字を変更
- テストコードの変更

~# 動作テスト~

## 実験方法
各indexに取得→設置までの経路が格納されていることを実際に経路を表示して確認、およびテストコードによる確認

~## 実験データ~

~|  修正前  |  修正後  |~
~| ---- | ---- |~
~|  -  |  -  |~
~|  -  |  -  |~

## 実験結果
**テストコードのpassに成功**
経路を表示したものを添付
![スクリーンショット 2021-08-30 203953](https://user-images.githubusercontent.com/66076307/131334164-8c0467a5-e5cb-4de3-b70e-ddccba50c7c7.png)

~## 添付資料~

## 備考
本チケットでの最短経路とticket-152の最短経路は異なるものになる