### PR TITLE
close #170 シミュレータの自動実行ツールにキャンセル機能を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 build/
 logs/
 
+# シミュレータ自動実行ツール関係
+.cancel-sim-test
+
 # Created by https://www.toptal.com/developers/gitignore/api/c++,macos,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=c++,macos,windows
 

--- a/scripts/sim-test-wsl.sh
+++ b/scripts/sim-test-wsl.sh
@@ -11,6 +11,11 @@ SETTINGS_FILES_DIR="`pwd`/sim-settings"
 DEFAULT_SETTINGS_FILE_NAME="${SETTINGS_FILES_DIR}/default.json"  # デフォルトのシミュレータ設定ファイル名
 ### 以上、設定  ###
 
+# シミュレータ自動実行ツールのキャンセル処理が実行されていないかを確認する
+if [ -f ".cancel-sim-test" ]; then
+    exit 0
+fi
+
 # WSL であるかどうかを確認する
 if [ ! -f /proc/sys/fs/binfmt_misc/WSLInterop ]; then
     echo "このスクリプトは、WSL上でしか動作しません"

--- a/sim-test-all.sh
+++ b/sim-test-all.sh
@@ -248,6 +248,14 @@ ls sim-settings/?/* | \
         print "走行エリア平均 : " run_time_average " [s] (n=" goaled_num ")";
         print "成功率        : " goal_persentage " [%] (n=" counter ")";
         ### 以上、標準出力 ###
-    }' && (cd ${LOG_FILES_DIR}; explorer.exe .)
+    }' && (cd ${LOG_FILES_DIR}; explorer.exe .) || :
     # 上記の && 以降で生成した Markdown 形式のファイルを開く処理を行っている
 ### 以上、シミュレータを実行し、結果を集計する ###
+
+
+if [ -f ".cancel-sim-test" ]; then
+    rm -f .cancel-sim-test
+    echo "sim stop" | ${HOME}/startetrobo shell
+    echo "キャンセルされました"
+    exit 800
+fi

--- a/sim-test-cancel.sh
+++ b/sim-test-cancel.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+
+# @file: sim-test-cancel.sh
+# @author: Takahiro55555
+# @brief: シミュレータの自動実行ツールを途中で停止させたい際に使用する。
+
+touch .cancel-sim-test
+echo "sim stop" | ${HOME}/startetrobo shell


### PR DESCRIPTION
# チェックリスト

- [ ] ~~clang-format している~~
- [ ] ~~コーディング規約に準じている~~
- [X] チケットの完了条件を満たしている

# 変更点
- シミュレータの自動実行ツールにキャンセル機能を追加

# 使い方
WSLで新たな端末（ターミナル）を立ち上げて以下のコマンドを実行した後、終了するまで待つ。

```
cd ~/etrobo/workspace/etrobocon2021
./sim-test-cancel.sh
```

# 動作テスト
手元の環境で動作を確認

https://user-images.githubusercontent.com/31930148/131489427-288716b2-dd73-40b2-bdc8-810ba4be1dc8.mp4

