### PR TITLE
close #175 シミュレータ自動実行ツールによって生成されたキャプチャ画像の削除機能を追加する

### DIFF
--- a/scripts/sim-test-wsl.sh
+++ b/scripts/sim-test-wsl.sh
@@ -33,11 +33,11 @@ elif [[ "$1" =~ ^\./.+$ ]]; then
 fi
 
 # ログファイルを出力するディレクトリへのパスをコマンドライン引数から取得する
-LOG_FILES_DIR_NAME="`pwd`/$3"
-if [[ "$3" =~ ^/.+$ ]]; then
-    LOG_FILES_DIR_NAME="$3"
-elif [[ "$3" =~ ^\./.+$ ]]; then
-    LOG_FILES_DIR_NAME="`pwd``echo $3 | cut -b 2-`"
+LOG_FILES_DIR_NAME="`pwd`/$2"
+if [[ "$2" =~ ^/.+$ ]]; then
+    LOG_FILES_DIR_NAME="$2"
+elif [[ "$2" =~ ^\./.+$ ]]; then
+    LOG_FILES_DIR_NAME="`pwd``echo $2 | cut -b 2-`"
 fi
 
 # ファイルが見つからない場合、プログラムを終了する

--- a/scripts/sim-test-wsl.sh
+++ b/scripts/sim-test-wsl.sh
@@ -66,33 +66,12 @@ if [ ! -f "${DEFAULT_SETTINGS_FILE_NAME}" ]; then
     exit 1
 fi
 
-# 設定ファイルから、ベースとなるキャプチャディレクトリへのパスを取得する
-BASE_CAPTURE_DIR_WIN=$(jq -sc add ${DEFAULT_SETTINGS_FILE_NAME} ${OVERWRITE_SETTINGS_FILE_NAME} | jq -r '.captureDir')
-if [[ "$BASE_CAPTURE_DIR_WIN" =~ ^$ ]]; then
-    UBUNTU_VER=$(lsb_release -a | grep -oE '^Release:\s*[0-9]{2}\.[0-9]{2}' | cut -f 2)
-    BASE_CAPTURE_DIR_WIN="\\\\wsl\$\\Ubuntu-${UBUNTU_VER}\\tmp\\etrobo\\capture"
-fi
+# キャプチャファイルを生成する一時ディレクトリを生成する
+CAPTURE_DIR_WSL=$(mktemp -d)
 
-# ベースとなるキャプチャディレクトリ配下に生成するディレクトリ名
-if [[ "$2" =~ ^$ ]]; then
-    CAPTURE_DIR_WIN="${BASE_CAPTURE_DIR_WIN}\\`date '+%Y-%m-%d'`\\`date '+%H-%M-%S'`\\${COURSE}\\${NAME}"
-else
-    if [[ "$2" =~ ^([0-9a-zA-Z_\-]+)(\\[0-9a-zA-Z_\-]+)?$ ]]; then
-        CAPTURE_DIR_WIN="${BASE_CAPTURE_DIR_WIN}\\$2\\${COURSE}\\${NAME}"
-    else
-        echo "Format Error (File path): ${2}"
-        echo 'Expected File Path Regex: ^([0-9a-zA-Z_\-]+)(\\[0-9a-zA-Z_\-]+)?$'
-        exit 1
-    fi
-fi
-
-# パスのフォーマットを WSL で扱える形式に変換する
-if [[ "${CAPTURE_DIR_WIN}" =~ ^\\\\wsl.+$ ]]; then
-    CAPTURE_DIR_WSL=$(echo "${CAPTURE_DIR_WIN}" | sed -r 's/^\\{2}wsl\$\\Ubuntu-[0-9\.]+\\/\\/g' | sed -e 's/\\/\//g')
-elif [[ ${CAPTURE_DIR_WIN} =~ ^[A-Z]:(\\.*)+$ ]]; then
-    CAPTURE_DIR_WSL="/mnt/`echo ${CAPTURE_DIR_WIN,} | cut -b 1`"
-    CAPTURE_DIR_WSL+=$(echo "${CAPTURE_DIR_WIN}" | sed -r 's/[A-Z]:(.+)/\1/g' | sed -e 's/\\/\//g')
-fi
+# 生成したキャプチャディレクトリをシミュレータからアクセスできる Windows 側のパスに変換する
+UBUNTU_VER=$(lsb_release -a | grep -oE '^Release:\s*[0-9]{2}\.[0-9]{2}' | cut -f 2)
+CAPTURE_DIR_WIN="\\\\wsl\$\\Ubuntu-${UBUNTU_VER}$(echo ${CAPTURE_DIR_WSL} | sed -r 's/\//\\/g')"
 
 # 設定ファイルの書き込み
 mkdir -p ${ETROBO_HRP3_WORKSPACE}/simdist/${APP_NAME};
@@ -105,11 +84,6 @@ jq -sc add ${DEFAULT_SETTINGS_FILE_NAME} ${OVERWRITE_SETTINGS_FILE_NAME} | \
 
 # キャプチャする際のフレームレートを取得
 CAPTURE_RATE=$(jq -r '.captureRate' ${EDITED_SETTINGS_FILE_NAME})
-
-# シミュレータによるキャプチャが有効化されている場合、キャプチャ先のディレクトリを生成
-if [[ ${CAPTURE_RATE} -ne 0 ]]; then
-    mkdir -p $CAPTURE_DIR_WSL
-fi
 
 # シミュレータに設定ファイルの内容を反映し、実行する
 echo "[ script: starting: $APP_NAME ]"
@@ -137,11 +111,16 @@ else
     exit 0
 fi
 # キャプチャ映像を MP4 に変換する
-cd $CAPTURE_DIR_WSL
-cd ../../
+L_OR_R=`echo ${COURSE} | tr lr LR`
 ffmpeg -framerate ${FRAME_RATE} \
-       -i ${CAPTURE_DIR_WSL}/`echo ${COURSE} | tr lr LR`_%08d.png \
+       -i ${CAPTURE_DIR_WSL}/${L_OR_R}_%08d.png \
        -vcodec libx264 \
        -pix_fmt yuv420p \
        -r ${FRAME_RATE} \
        ${LOG_FILES_DIR_NAME}/${COURSE}-${NAME}.mp4
+
+# CSV ファイルをコピーする
+cp ${CAPTURE_DIR_WSL}/${L_OR_R}.csv ${LOG_FILES_DIR_NAME}/.logs/${COURSE}-${NAME}.csv
+
+# 一時ディレクトリを削除する
+rm -rf ${CAPTURE_DIR_WSL}

--- a/sim-test-all.sh
+++ b/sim-test-all.sh
@@ -39,8 +39,7 @@ fi
 
 
 ### 以下、シミュレータを実行し、結果を集計する ###
-mkdir -p ${LOG_FILES_DIR};
-CAPTURE_DIR=${DAY}\\${TIME}
+mkdir -p ${LOG_FILES_DIR}/.logs
 
 # シミュレータを起動
 echo 'sim' | ${HOME}/startetrobo shell
@@ -48,7 +47,7 @@ echo 'sim' | ${HOME}/startetrobo shell
 # 設定ファイルをシミュレータに反映した後、プログラムを実行する
 # awk コマンドの -v オプションで awk 中のスクリプトにシェル変数を渡している
 ls sim-settings/?/* | \
-    xargs -L1 -I{} ./scripts/sim-test-wsl.sh {} ${CAPTURE_DIR} ${LOG_FILES_DIR} | \
+    xargs -L1 -I{} ./scripts/sim-test-wsl.sh {} ${LOG_FILES_DIR} | \
     awk -v md_file_path=${LOG_FILES_DIR}/${MD_FILE_NAME} \
         -v csv_file_name=${LOG_FILES_DIR}/${CSV_FILE_NAME} '
     BEGIN {


### PR DESCRIPTION
# チェックリスト

- [ ] ~~clang-format している~~
- [X] コーディング規約に準じている
- [X] チケットの完了条件を満たしている

# 変更点
- ループが回る毎に、キャプチャ画像を都度削除するようにした
- ついでに、シミュレーションが早く終了すると走行開始前の映像が後半部分にくっついてくる問題を解消

# 動作テスト
- ローカル環境で実際に動作させた

## 実験結果

### キャプチャ画像の削除
ツール実行前のキャプチャ画像ディレクトリの親ディレクトリと実行後の親ディレクトリに変化が無いことを確認。
つまり、ツールによって生成された一時ディレクトリ（及びファイル）はツールによって削除されたことを確認。

具体的には以下のコマンドを実行することによって確認をした。
```
ls /tmp/ > ls-tmp-before.txt
./sim-test-all.sh ; ls /tmp/ > ls-tmp-after.txt
diff ls-tmp-before.txt ls-tmp-after.txt 
```

### 走行開始前の映像が後半部分にくっついてくる問題の解消
以下時示すキャプチャ映像から問題の解消を確認。

#### Before

https://user-images.githubusercontent.com/31930148/131846549-d13c6bbd-6614-45ea-b971-4074585a72dd.mp4


#### After


https://user-images.githubusercontent.com/31930148/131846596-29ef3771-0ba7-4c9b-8dcd-5ada660d15ec.mp4


