### PR TITLE
close #146 CIのシミュレータテストにビンゴエリアの結果を反映する

### DIFF
--- a/.github/workflows/sim-test.yaml
+++ b/.github/workflows/sim-test.yaml
@@ -33,11 +33,13 @@ jobs:
 
   simulator-test:
     runs-on: self-hosted
-    needs: build-check
+    # needs: build-check
     env:
       ETROBO_ROOT: /home/etrobocon2021/etrobo
       SIM_LOG_FILE: sim-log.txt
       MP4_SERVER_NAME: etrobocon2021.moyashi.dev
+      MAX_SIM_TIME: 4
+      APP_NAME: etrobocon2021
 
     steps:
     - uses: actions/checkout@v2
@@ -46,118 +48,359 @@ jobs:
     - name: Set up simulator
       shell: bash
       run: |
-        # 一時ファイル、ディレクトリの作成
-        TMP_CAPTURE_DIR=$(mktemp -d)
-        TMP_SETTINGS_FILE=$(mktemp --suffix=.json)
+        # もし、etrobocon2021 ディレクトリが既に存在する場合は削除
+        etrobo_cmd=''
+        etrobo_cmd+='if [ -d ${ETROBO_HRP3_WOKSPACE}/${{ env.APP_NAME }} ]; then rm -rf ${ETROBO_HRP3_WORKSPACE}/${{ env.APP_NAME }}; fi; '
 
-        # 初期ブロック配置をランダムに生成
-        BLOCK_COORDINATE_L='09'$(echo "from random import *; print(''.join(sample('EMBKDRGP',8)))" | python3)
+        # etrobo環境に、etrobocon2021リポジトリへのシンボリックリンクを作成
+        etrobo_cmd+='ln -s ${{ github.workspace }} ${ETROBO_HRP3_WORKSPACE}/${{ env.APP_NAME }}; '
 
-        # キャプチャ関連の設定 (FPS=30)
-        cat ${{ github.workspace }}/sim-settings/default.json | \
-          jq ".captureDir=\"${TMP_CAPTURE_DIR}\"" | \
-          jq ".captureRate=\"2\"" | \
-          jq ".initLBlockLayout=\"${BLOCK_COORDINATE_L}\"" > ${TMP_SETTINGS_FILE}
-
-        # 環境変数へ保存
-        echo TMP_CAPTURE_DIR=$TMP_CAPTURE_DIR >> $GITHUB_ENV
-        echo TMP_SETTINGS_FILE=$TMP_SETTINGS_FILE >> $GITHUB_ENV
-        echo BLOCK_COORDINATE_L=$BLOCK_COORDINATE_L >> $GITHUB_ENV
+        # etrobo環境で上述のコマンドを実行
+        echo ${etrobo_cmd} | ${HOME}/startetrobo shell
 
     # シミュレータを研究室のPCで実行する
     - name: Test on simulator
       shell: bash
       run: |
-        export DISPLAY=:0
-        SIM_COMMANDS=''
-        # etrobo環境に、etrobocon2021リポジトリへのシンボリックリンクを作成
-        SIM_COMMANDS+='if [ -d ${ETROBO_HRP3_WORKSPACE}/etrobocon2021 ]; then rm -rf ${ETROBO_HRP3_WORKSPACE}/etrobocon2021; fi; '
-        SIM_COMMANDS+='ln -s ${{ github.workspace }} ${ETROBO_HRP3_WORKSPACE}/etrobocon2021; '
+        # 初期コメントの生成
+        MSG_RESULT=""
+        MSG_RESULT+="## 結果\n"
+        MSG_RESULT+="|No|コース|走行タイム [s]|ボーナスタイム [s]|リザルトタイム [s]|ブロック配置|動画|\n"
+        MSG_RESULT+="|--|-----|-------------|----------------|-----------------|-----------|----|\n"
 
-        # シミュレータの設定を反映
-        SIM_COMMANDS+='curl -X POST -H \"Content-Type: application/json\" -d @${{ env.TMP_SETTINGS_FILE }} http://localhost:54000; '
-        
-        # シミュレーションの実行
-        SIM_COMMANDS+='make left app=etrobocon2021 sim up; '
+        MSG_DETAIL=""
+        MSG_DETAIL+="<details>\n"
+        MSG_DETAIL+="<summary>詳細を表示</summary>\n"
+        MSG_DETAIL+="\n"
+        MSG_DETAIL+="|No|スタートゲート通過|ゲート1通過|ゲート2通過|走行タイム [s]|ブロックサークル有効移動|パワースポット有効移動|センターブロック有効移動|ビンゴ|パワースポットビンゴ|ボーナスタイム[s]|リザルトタイム[s]|ブロック配置|MP4|CSV|LOG|settings.json|\n"
+        MSG_DETAIL+="|--|---------------|---------|---------|-------------|-------------------|-------------------|-------------------|------|----------------|--------------|--------------|----------|---|---|---|-------------|\n"
 
-        # 後始末
-        SIM_COMMANDS+='unlink ${ETROBO_HRP3_WORKSPACE}/etrobocon2021; '
+        MSG_DETAIL_TAIL="</details>\n\n"
 
-        # etrobo環境で上述のコマンドを実行
-        echo ${SIM_COMMANDS} | ${HOME}/startetrobo shell | tee ${SIM_LOG_FILE}
+        MSG_SUMMARY_HEAD=""
+        MSG_SUMMARY_HEAD+="### 集計結果\n"
 
-    # シミュレータのキャプチャ映像をMP4に変換する
-    - name: Convert capture image to MP4
-      shell: bash
-      run: |
-        # ディレクトリの生成
-        MP4_DIR=mp4s/$(date '+%Y-%m-%d/%H-%M-%S')
-        mkdir -p ${HOME}/Videos/${MP4_DIR}
+        MSG_SUMMARY_DETAIL_HEAD=""
+        MSG_SUMMARY_DETAIL_HEAD+="<details>\n"
+        MSG_SUMMARY_DETAIL_HEAD+="<summary>詳細を表示</summary>\n\n"
+        MSG_SUMMARY_DETAIL_TAIL="</details>\n\n"
+        MSG_SUMMARY_DETAIL_HEAD+="|項目|結果|母数|\n"
+        MSG_SUMMARY_DETAIL_HEAD+="|---|----|---|\n"
 
-        # シミュレータのキャプチャ映像をMP4に変換
-        ffmpeg -y \
-               -framerate 30 \
-               -i ${{ env.TMP_CAPTURE_DIR}}/L_%08d.png \
-               -vcodec libx264 -pix_fmt yuv420p \
-               -r 30 ${HOME}/Videos/${MP4_DIR}/${{ github.sha }}.mp4
+        MSG_TAIL=":arrows_counterclockwise: Testing now... (1/${MAX_SIM_TIME})"
 
-        # CSVファイルのコピー
-        cp ${{ env.TMP_CAPTURE_DIR}}/*.csv ${HOME}/Videos/${MP4_DIR}/${{ github.sha }}.csv
+        # プルリクの Issue 番号の取得 (on: pull_request のイベントによってトリガーされた場合のみ)
+        ISSUE_NUMBER=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")
 
-        # 環境変数へディレクトリ名を保存
-        echo MP4_DIR=$MP4_DIR >> $GITHUB_ENV
+        # プルリクコメントの投稿とコメントIDの取得
+        COMMENT_ID=$(curl \
+                      -X POST \
+                      -H "Accept: application/vnd.github.v3+json" \
+                      -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                      ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/comments \
+                      -d "{\"body\":\"${MSG_TAIL}\"}" | jq -r '.id')
 
-    # 走行結果から、走行テストの成否を判定
-    - name: Judge
-      shell: bash
-      run: |
-        # スタートできていない場合、テスト失敗
-        if [ "`cat ${SIM_LOG_FILE} | grep -coE '\[ launcher: Go!* \]' || :`" == "0" ]; then
-          echo "Could not detect START"
-          exit 999
-        fi
+        # テスト結果公開用ディレクトリの生成
+        TEST_RESULT_DIR_ROOT=${HOME}/Videos
+        TEST_RESULT_DIR=results/$(date '+%Y-%m-%d/%H-%M-%S')
+        mkdir -p ${TEST_RESULT_DIR_ROOT}/${TEST_RESULT_DIR}
 
-        # 各ゲートを通過したかどうかの確認
-        PASSED_START_GATE="`cat ${SIM_LOG_FILE} | \
-                            grep -coE '\[ launcher: left: passed Start Gate \]' || :`"
-        PASSED_GATE_1="`cat ${SIM_LOG_FILE} | \
-                            grep -coE '\[ launcher: left: passed Gate 1 \]' || :`"
-        PASSED_GATE_2="`cat ${SIM_LOG_FILE} | \
-                            grep -coE '\[ launcher: left: passed Gate 2 \]' || :`"
-        PASSED_GALE_GATE="`cat ${SIM_LOG_FILE} | \
-                      grep -coE '\[ launcher: left: GOAL!  Goal Time: ([0-9]*\.?[0-9]*) \]' || :`"
+        # 集計用変数
+        L_COUNTER=0
+        L_GOAL_COUNTER=0
+        L_GOAL_TIME_SUM=0
+        L_BONUS_TIME_SUM=0
+        L_RESULT_TIME_SUM=0  # NOTE: 無くても良いが有ったほうが楽
 
-        # 走行時間の取得
-        if [ "${PASSED_GALE_GATE}" == '0' ]; then
-          RESULT_TIME='None'
-        else
-          RESULT_TIME="`cat ${SIM_LOG_FILE} | \
-                        grep -oE '\[ launcher: left: GOAL!  Goal Time: ([0-9]*\.?[0-9]*) \]' | \
-                        sed -r 's/^\[ launcher: left: GOAL!  Goal Time: ([0-9]*\.?[0-9]*) \]$/\1/g'` [s]"
-        fi
+        R_COUNTER=0
+        R_GOAL_COUNTER=0
+        R_GOAL_TIME_SUM=0
+        R_BONUS_TIME_SUM=0
+        R_RESULT_TIME_SUM=0  # NOTE: 無くても良いが有ったほうが楽
 
-        # GitHubへ投稿するメッセージの作成
-        RESULT_MESSAGE=''
-        RESULT_MESSAGE+="|項目|結果|\n"
-        RESULT_MESSAGE+="|---|---|\n"
-        RESULT_MESSAGE+="|スタートゲート通過| ${PASSED_START_GATE} |\n"
-        RESULT_MESSAGE+="|ゲート1通過| ${PASSED_GATE_1} |\n"
-        RESULT_MESSAGE+="|ゲート2通過| ${PASSED_GATE_2} |\n"
-        RESULT_MESSAGE+="|走行タイム| ${RESULT_TIME} |\n\n"
-        RESULT_MESSAGE+="※ 0: 通過失敗, 1: 通過成功\n"
-        RESULT_MESSAGE+="※ ブロックの初期配置 ${{ env.BLOCK_COORDINATE_L }}\n\n"
-        RESULT_MESSAGE+="[:arrow_forward: シミュレータの動画](https://${{ env.MP4_SERVER_NAME }}/01/${{ env.MP4_DIR }}/${{ github.sha }}.mp4)"
+        BEST_RESULT_TIME=120
 
-        # 生成したメッセージを環境変数へ保存
-        echo RESULT_MESSAGE=$RESULT_MESSAGE >> $GITHUB_ENV
+        ###  シミュレーションを複数回実行する。　　　　　　　　　　　　　　　　　　　###
+        ###  他のシミュレーションテストのリクエストが発生した場合、　　　　　　　　　###
+        ###  実行中のシミュレーションが終了次第、シミュレーションテストを終了する。　###
+        for ((i=1; i<=${MAX_SIM_TIME}; i++)); do
+          # キャプチャ画像用一時ディレクトリの生成
+          TMP_CAPTURE_DIR=$(mktemp -d)
+          echo ${TMP_CAPTURE_DIR}
 
-    # 走行タイムをコメントとして載せる
-    - uses: actions/github-script@0.8.0
-      with:
-        script: |
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: '${{ env.RESULT_MESSAGE }}'
-          })
+          # 初期ブロック配置をランダムに生成
+          BLOCK_COORDINATE_L='09'$(echo "from random import *; print(''.join(sample('EMBKDRGP',8)))" | python3)
+          BLOCK_COORDINATE_R='09'$(echo "from random import *; print(''.join(sample('HJCLAQFS',8)))" | python3)
+
+          # シミュレータの設定ファイルを生成
+          SETTINGS_FILE=${TEST_RESULT_DIR}/${GITHUB_SHA}-${i}.json
+          cat ${GITHUB_WORKSPACE}/sim-settings/default.json | \
+            jq ".captureDir=\"${TMP_CAPTURE_DIR}\"" | \
+            jq ".captureRate=\"2\"" | \
+            jq ".initLBlockLayout=\"${BLOCK_COORDINATE_L}\"" | \
+            jq ".initRBlockLayout=\"${BLOCK_COORDINATE_R}\"" > ${TEST_RESULT_DIR_ROOT}/${SETTINGS_FILE}
+
+          # シミュレータに設定ファイルを反映させる
+          curl -X POST \
+              -H "Content-Type: application/json" \
+              -d @${TEST_RESULT_DIR_ROOT}/${SETTINGS_FILE} \
+              http://localhost:54000
+
+          # 走行コースの設定
+          A=('r' 'l')
+          COURSE_LOWER=${A[$(( i % 2))]}
+          COURSE_UPPER=$(echo ${COURSE_LOWER} | tr lr LR)
+
+          # シミュレーションの実行
+          LOG_FILE=${TEST_RESULT_DIR}/${GITHUB_SHA}-${i}.log
+          echo "make ${COURSE_LOWER} app=${APP_NAME} sim up" | \
+            ${HOME}/startetrobo shell | \
+            tee ${TEST_RESULT_DIR_ROOT}/${LOG_FILE}
+
+          # CSVファイルのコピー
+          CSV_FILE=${TEST_RESULT_DIR}/${GITHUB_SHA}-${i}.csv
+          cp ${TMP_CAPTURE_DIR}/${COURSE_UPPER}.csv \
+            ${TEST_RESULT_DIR_ROOT}/${CSV_FILE}
+
+          # スタート前に撮影されたキャプチャ画像を削除する。
+          # 一番最後のフレームが消えることになるが、
+          # ゴール後 1 フレーム以上のキャプチャ画像が生成されるため、
+          # 問題は無いと判断。
+          CSV_TAIL_NUM=$(cat ${TEST_RESULT_DIR_ROOT}/${CSV_FILE} | \
+                            tail -n1 | \
+                            sed -r 's/.*(L|R)_([0-9]{8})\.png.*/\2/g')
+          PNG_TAIL_NUM=$(ls ${TMP_CAPTURE_DIR}/*.png | \
+                            tail -n1 | \
+                            sed -r 's/.*(L|R)_([0-9]{8})\.png/\2/g')
+          echo "echo ${TMP_CAPTURE_DIR}/${COURSE_UPPER}_{${CSV_TAIL_NUM}..${PNG_TAIL_NUM}}.png" | bash | xargs -L1 rm -f
+
+          # キャプチャ画像をMP4に変換
+          MP4_FILE=${TEST_RESULT_DIR}/${GITHUB_SHA}-${i}.mp4
+          ffmpeg -y \
+                -framerate 30 \
+                -i ${TMP_CAPTURE_DIR}/$(echo ${COURSE_LOWER} | tr lr LR)_%08d.png \
+                -vcodec libx264 -pix_fmt yuv420p \
+                -r 30 ${TEST_RESULT_DIR_ROOT}/${MP4_FILE}
+
+          # CSV ファイルを JSON ファイルに変換する
+          # (Windows環境で生成されたCSVを変換する場合、OSの差異による改行文字の違いに注意)
+          jq --compact-output -s -R 'split("\n")|map(split(","))|map({
+              "Time": .[0], 
+              "Counter": .[1], 
+              "Filename": .[2], 
+              "TIME": .[3], 
+              "MEASUREMENT_TIME": .[4], 
+              "RUN_TIME": .[5], 
+              "GATE1": .[6], 
+              "GATE2": .[7], 
+              "GOAL": .[8], 
+              "GARAGE_STOP": .[9], 
+              "GARAGE_TIME": .[10], 
+              "SLALOM": .[11], 
+              "PETBOTTLE": .[12], 
+              "BLOCK_IN_GARAGE": .[13], 
+              "BLOCK_YUKOIDO": .[14], 
+              "CARD_NUMBER_CIRCLE": .[15], 
+              "BLOCK_NUMBER_CIRCLE": .[16], 
+              "BLOCK_BINGO": .[17], 
+              "ENTRY_BONUS": .[18], 
+              "BLOCK_YUKOIDOP": .[19], 
+              "BLOCK_YUKOIDOC": .[20], 
+              "BLOCK_BINGOP": .[21], 
+              "MeasurementMode": .[22]
+            })' ${TEST_RESULT_DIR_ROOT}/${CSV_FILE} > ${TEST_RESULT_DIR_ROOT}/${CSV_FILE}.json
+
+          # ビンゴエリアの結果を一時保存するためのJSONファイルを生成
+          TMP_JSON_FILE=$(mktemp --suffix=.json)
+          echo ${TMP_JSON_FILE}
+
+          # ビンゴエリアの最終結果を抽出し、一時ファイルに保存
+          cat ${TEST_RESULT_DIR_ROOT}/${CSV_FILE}.json | \
+            jq '.[] | select(.MeasurementMode=="END")' | \
+            jq -s '.' | \
+            jq 'max_by(.TIME)' > ${TMP_JSON_FILE}
+
+          echo "[DEBUG 00] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+          # ビンゴエリアの最終結果を集計する
+          BLOCK_YUKOIDO=$(jq -r '.BLOCK_YUKOIDO' ${TMP_JSON_FILE})
+          POWER_SPOT_YUKOIDO=$(jq -r '.BLOCK_YUKOIDOP' ${TMP_JSON_FILE})
+          CENTER_BLOCK_YUKOIDO=$(jq -r '.BLOCK_YUKOIDOC' ${TMP_JSON_FILE})
+          BLOCK_BINGO=$(jq -r '.BLOCK_BINGO' ${TMP_JSON_FILE})
+          POWERS_POT_BINGO=$(jq -r '.BLOCK_BINGOP' ${TMP_JSON_FILE})
+
+          echo "[DEBUG 01] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+          # ボーナスタイムの計算
+          BLOCK_YUKOIDO_BONUS_TIME=$(echo ${BLOCK_YUKOIDO} | awk '{print $1 / 2}')
+          POWER_SPOT_YUKOIDO_BONUS_TIME=${POWER_SPOT_YUKOIDO}
+          CENTER_BLOCK_YUKOIDO_BONUS_TIME=$(echo ${CENTER_BLOCK_YUKOIDO} | awk '{print $1 * 2}')
+          BLOCK_BINGO_BONUS_TIME=${BLOCK_BINGO}
+          POWER_SPOT_BINGO_BONUS_TIME=$(echo ${POWERS_POT_BINGO} | awk '{print $1 * 2}')
+          BONUS_TIME=$(echo ${BLOCK_YUKOIDO_BONUS_TIME} \
+                            ${POWER_SPOT_YUKOIDO_BONUS_TIME} \
+                            ${CENTER_BLOCK_YUKOIDO_BONUS_TIME} \
+                            ${BLOCK_BINGO_BONUS_TIME} \
+                            ${POWER_SPOT_BINGO_BONUS_TIME} \
+                            | awk '{print $1 + $2 + $3 + $4 + $5}')
+
+          echo "[DEBUG 02] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+          # 各ゲートを通過したかどうかの確認
+          PASSED_START_GATE=$(cat ${TEST_RESULT_DIR_ROOT}/${LOG_FILE} | \
+                              grep -coE '\[ launcher: ((left)|(right)): passed Start Gate \]' || :)
+          PASSED_GATE_1=$(cat ${TEST_RESULT_DIR_ROOT}/${LOG_FILE} | \
+                              grep -coE '\[ launcher: ((left)|(right)): passed Gate 1 \]' || :)
+          PASSED_GATE_2=$(cat ${TEST_RESULT_DIR_ROOT}/${LOG_FILE} | \
+                              grep -coE '\[ launcher: ((left)|(right)): passed Gate 2 \]' || :)
+          PASSED_GALE_GATE=$(cat ${TEST_RESULT_DIR_ROOT}/${LOG_FILE} | \
+                              grep -coE '\[ launcher: ((left)|(right)): GOAL!  Goal Time: ([0-9]*\.?[0-9]*) \]' || :)
+
+          echo "[DEBUG 03] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+          # 走行時間の取得 (ゴールゲートの通過)、リザルトタイムの算出
+          if [ "${PASSED_GALE_GATE}" == '0' ]; then
+            echo "[DEBUG 03.1] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+            GOAL_TIME='None'
+            RESULT_TIME='None'
+          else
+            echo "[DEBUG 03.2] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+            GOAL_TIME="$(cat ${TEST_RESULT_DIR_ROOT}/${LOG_FILE} | \
+                          grep -oE '\[ launcher: ((left)|(right)): GOAL!  Goal Time: ([0-9]*\.?[0-9]*) \]' | \
+                          grep -oE '[0-9]*\.?[0-9]*')"
+            
+            echo "[DEBUG 03.3] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+            # リザルトタイムの計算
+            RESULT_TIME=$(echo ${GOAL_TIME} ${BONUS_TIME} | awk '{print $1 - $2}')
+
+            echo "[DEBUG 03.4] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+            # ベストタイムの更新
+            if [ "$(echo "${RESULT_TIME} < ${BEST_RESULT_TIME}" | bc)" -eq 1 ]; then
+              BEST_RESULT_TIME=${RESULT_TIME}
+            fi
+
+            echo "[DEBUG 04] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+            # 集計用変数の更新
+            if [ "${COURSE_UPPER}" == "L" ]; then
+              L_GOAL_TIME_SUM+=$(echo ${L_GOAL_TIME_SUM} ${GOAL_TIME} | awk '{print $1 + $2}')
+              L_BONUS_TIME_SUM+=$(echo ${L_BONUS_TIME_SUM} ${BONUS_TIME} | awk '{print $1 + $2}')
+              L_RESULT_TIME_SUM+=$(echo ${L_RESULT_TIME_SUM} ${RESULT_TIME} | awk '{print $1 + $2}')
+              echo $(( L_GOAL_COUNTER++ ))
+            elif [ "${COURSE_UPPER}" == "R" ]; then
+              R_GOAL_TIME_SUM+=$(echo ${R_GOAL_TIME_SUM} ${GOAL_TIME} | awk '{print $1 + $2}')
+              R_BONUS_TIME_SUM+=$(echo ${R_BONUS_TIME_SUM} ${BONUS_TIME} | awk '{print $1 + $2}')
+              R_RESULT_TIME_SUM+=$(echo ${R_RESULT_TIME_SUM} ${RESULT_TIME} | awk '{print $1 + $2}')
+              echo $(( R_GOAL_COUNTER++ ))
+            fi
+          fi
+
+          echo "[DEBUG 05] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+          
+          # 走行回数カウンターの更新
+          if [ "${COURSE_UPPER}" == "L" ]; then
+            echo $(( L_COUNTER++ ))
+          elif [ "${COURSE_UPPER}" == "R" ]; then
+            echo $(( R_COUNTER++ ))
+          fi
+
+          echo "[DEBUG 06] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+          # コメント用集計結果の計算
+          L_GOAL_RATE=$(echo ${L_GOAL_COUNTER} ${L_COUNTER} | awk '{if($2>0){print $1 / $2 * 100}else{print 0}}')
+          R_GOAL_RATE=$(echo ${R_GOAL_COUNTER} ${R_COUNTER} | awk '{if($2>0){print $1 / $2 * 100}else{print 0}}')
+          LR_GOAL_RATE=$(echo ${L_GOAL_COUNTER} ${R_GOAL_COUNTER} ${i} | awk '{if($3>0){print ($1 + $2) / $3 * 100}else{print 0}}')
+          L_GOAL_TIME_AVG=$(echo ${L_GOAL_TIME_SUM} ${L_GOAL_COUNTER} | awk '{if($2>0){print $1 / $2}else{print 0}}')
+          R_GOAL_TIME_AVG=$(echo ${R_GOAL_TIME_SUM} ${R_GOAL_COUNTER} | awk '{if($2>0){print $1 / $2}else{print 0}}')
+          LR_GOAL_TIME_AVG=$(echo ${L_GOAL_TIME_SUM} ${R_GOAL_TIME_SUM} ${L_GOAL_COUNTER} ${R_GOAL_COUNTER} | \
+                              awk '{if(($3+$4)>0){print ($1 + $2) / ($3 + $4)}else{print 0}}')
+          L_BONUS_TIME_AVG=$(echo ${L_BONUS_TIME_SUM} ${L_GOAL_COUNTER} | awk '{if($2>0){print $1 / $2}else{print 0}}')
+          R_BONUS_TIME_AVG=$(echo ${R_BONUS_TIME_SUM} ${R_GOAL_COUNTER} | awk '{if($2>0){print $1 / $2}else{print 0}}')
+          LR_BONUS_TIME_AVG=$(echo ${L_BONUS_TIME_SUM} ${R_BONUS_TIME_SUM} ${L_GOAL_COUNTER} ${R_GOAL_COUNTER} | \
+                              awk '{if(($3+$4)>0){print ($1 + $2) / ($3 + $4)}else{print 0}}')
+          L_RESULT_TIME_AVG=$(echo ${L_RESULT_TIME_SUM} ${L_GOAL_COUNTER} | awk '{if($2>0){print $1 / $2}else{print 0}}')
+          R_RESULT_TIME_AVG=$(echo ${R_RESULT_TIME_SUM} ${R_GOAL_COUNTER} | awk '{if($2>0){print $1 / $2}else{print 0}}')
+          LR_RESULT_TIME_AVG=$(echo ${L_RESULT_TIME_SUM} ${R_RESULT_TIME_SUM} ${L_GOAL_COUNTER} ${R_GOAL_COUNTER} | \
+                              awk '{if(($3+$4)>0){print ($1 + $2) / ($3 + $4)}else{print 0}}')
+
+          echo "[DEBUG 07] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+          # コメントの作成
+          MSG_RESULT+="|${i}|${COURSE_UPPER}|${GOAL_TIME}|${BONUS_TIME}|${RESULT_TIME}|"
+
+          MSG_DETAIL+="|${i}|${PASSED_START_GATE}|${PASSED_GATE_1}|${PASSED_GATE_2}|${GOAL_TIME}"
+          MSG_DETAIL+="|${BLOCK_YUKOIDO_BONUS_TIME}|${POWER_SPOT_YUKOIDO_BONUS_TIME}"
+          MSG_DETAIL+="|${CENTER_BLOCK_YUKOIDO_BONUS_TIME}|${BLOCK_BINGO_BONUS_TIME}"
+          MSG_DETAIL+="|${POWER_SPOT_BINGO_BONUS_TIME}|${BONUS_TIME}|${RESULT_TIME}|"
+
+          if [ "${COURSE_UPPER}" == "L" ]; then
+            MSG_RESULT+="${BLOCK_COORDINATE_L}|"
+            MSG_DETAIL+="${BLOCK_COORDINATE_L}|"
+          elif [ "${COURSE_UPPER}" == "R" ]; then
+            MSG_RESULT+="${BLOCK_COORDINATE_R}|"
+            MSG_DETAIL+="${BLOCK_COORDINATE_R}|"
+          fi
+          MSG_RESULT+="[:arrow_forward: 動画](https://${MP4_SERVER_NAME}/01/${MP4_FILE})|\n"
+          MSG_DETAIL+="[MP4](https://${MP4_SERVER_NAME}/01/${MP4_FILE})|"
+          MSG_DETAIL+="[CSV](https://${MP4_SERVER_NAME}/01/${CSV_FILE})|"
+          MSG_DETAIL+="[LOG](https://${MP4_SERVER_NAME}/01/${LOG_FILE})|"
+          MSG_DETAIL+="[JSON](https://${MP4_SERVER_NAME}/01/${SETTINGS_FILE})|\n"
+          
+
+          MSG_SUMMARY=""
+          MSG_SUMMARY+="全体ゴール率: ${LR_GOAL_RATE} [%] (n = ${i})\n"
+          MSG_SUMMARY+="全体平均リザルトタイム: ${LR_RESULT_TIME_AVG} [S] (n = $((L_GOAL_COUNTER + R_GOAL_COUNTER)))\n"
+          MSG_SUMMARY+="最速リザルトタイム: ${BEST_RESULT_TIME} [S]\n"
+
+          MSG_SUMMARY_DETAIL=""
+          MSG_SUMMARY_DETAIL+="|Lゴール率[%]|${L_GOAL_RATE}|${L_COUNTER}|\n"
+          MSG_SUMMARY_DETAIL+="|Rゴール率[%]|${R_GOAL_RATE}|${R_COUNTER}|\n"
+          MSG_SUMMARY_DETAIL+="|全体ゴール率[%]|${LR_GOAL_RATE}|$((L_COUNTER + R_COUNTER))|\n"
+          MSG_SUMMARY_DETAIL+="| | | |\n"
+          MSG_SUMMARY_DETAIL+="|L平均ゴールタイム[S]|${L_GOAL_TIME_AVG}|${L_GOAL_COUNTER}|\n"
+          MSG_SUMMARY_DETAIL+="|R平均ゴールタイム[S]|${R_GOAL_TIME_AVG}|${R_GOAL_COUNTER}|\n"
+          MSG_SUMMARY_DETAIL+="|全体平均ゴールタイム[S]|${LR_GOAL_TIME_AVG}|$((L_GOAL_COUNTER + R_GOAL_COUNTER))|\n"
+          MSG_SUMMARY_DETAIL+="| | | |\n"
+          MSG_SUMMARY_DETAIL+="|L平均ボーナスタイム[S]|${L_BONUS_TIME_AVG}|${L_GOAL_COUNTER}|\n"
+          MSG_SUMMARY_DETAIL+="|R平均ボーナスタイム[S]|${R_BONUS_TIME_AVG}|${R_GOAL_COUNTER}|\n"
+          MSG_SUMMARY_DETAIL+="|全体平均ボーナスタイム[S]|${LR_BONUS_TIME_AVG}|$((L_GOAL_COUNTER + R_GOAL_COUNTER))|\n"
+          MSG_SUMMARY_DETAIL+="| | | |\n"
+          MSG_SUMMARY_DETAIL+="|L平均リザルトタイム[S]|${L_RESULT_TIME_AVG}|${L_GOAL_COUNTER}|\n"
+          MSG_SUMMARY_DETAIL+="|R平均リザルトタイム[S]|${R_RESULT_TIME_AVG}|${R_GOAL_COUNTER}|\n"
+          MSG_SUMMARY_DETAIL+="|平均リザルトタイム[S]|${LR_RESULT_TIME_AVG}|$((L_GOAL_COUNTER + R_GOAL_COUNTER))|\n"
+
+          MSG_TAIL=":arrows_counterclockwise: Testing now... ($((i + 1))/${MAX_SIM_TIME})"
+
+          # 待ち状態になっているジョブ？が無いか確認する
+          QUEUED_JOB_NUM=$(curl -H "Accept: application/vnd.github.v3+json" \
+                                ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs?status=queued\&per_page=99 | \
+                              jq ".workflow_runs[] | select( .name == \"${GITHUB_WORKFLOW}\" ) | .id" | \
+                              wc -l)
+
+          echo "[DEBUG 08] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+          # ループ終了時の片づけ
+          if [[ "${i}" == "${MAX_SIM_TIME}" || "${QUEUED_JOB_NUM}" != "0" ]]; then
+            MSG_TAIL=""
+            i=${MAX_SIM_TIME}
+          fi
+
+          echo "[DEBUG 08] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
+
+          # プルリクコメントのアップデート
+          MSG="${MSG_RESULT}${MSG_DETAIL}${MSG_DETAIL_TAIL}${MSG_SUMMARY_HEAD}${MSG_SUMMARY}${MSG_SUMMARY_DETAIL_HEAD}${MSG_SUMMARY_DETAIL}${MSG_SUMMARY_DETAIL_TAIL}${MSG_TAIL}"
+          curl \
+            -X PATCH \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID} \
+            -d "{\"body\":\"${MSG}\"}" | \
+          jq -r '.html_url'
+
+          # いらないファイル・ディレクトリの削除
+          rm -rf ${TMP_CAPTURE_DIR} ${TMP_JSON_FILE}
+        done
+
+        # シンボリックリンクの削除（etrobo環境で実行）
+        echo 'unlink ${ETROBO_HRP3_WORKSPACE}/${{ env.APP_NAME }}' | ${HOME}/startetrobo shell
+

--- a/.github/workflows/sim-test.yaml
+++ b/.github/workflows/sim-test.yaml
@@ -38,7 +38,7 @@ jobs:
       ETROBO_ROOT: /home/etrobocon2021/etrobo
       SIM_LOG_FILE: sim-log.txt
       MP4_SERVER_NAME: etrobocon2021.moyashi.dev
-      MAX_SIM_TIME: 4
+      MAX_SIM_TIME: 20
       APP_NAME: etrobocon2021
 
     steps:

--- a/.github/workflows/sim-test.yaml
+++ b/.github/workflows/sim-test.yaml
@@ -33,7 +33,7 @@ jobs:
 
   simulator-test:
     runs-on: self-hosted
-    # needs: build-check
+    needs: build-check
     env:
       ETROBO_ROOT: /home/etrobocon2021/etrobo
       SIM_LOG_FILE: sim-log.txt

--- a/.github/workflows/sim-test.yaml
+++ b/.github/workflows/sim-test.yaml
@@ -269,14 +269,14 @@ jobs:
 
             # 集計用変数の更新
             if [ "${COURSE_UPPER}" == "L" ]; then
-              L_GOAL_TIME_SUM+=$(echo ${L_GOAL_TIME_SUM} ${GOAL_TIME} | awk '{print $1 + $2}')
-              L_BONUS_TIME_SUM+=$(echo ${L_BONUS_TIME_SUM} ${BONUS_TIME} | awk '{print $1 + $2}')
-              L_RESULT_TIME_SUM+=$(echo ${L_RESULT_TIME_SUM} ${RESULT_TIME} | awk '{print $1 + $2}')
+              L_GOAL_TIME_SUM=$(echo ${L_GOAL_TIME_SUM} ${GOAL_TIME} | awk '{print $1 + $2}')
+              L_BONUS_TIME_SUM=$(echo ${L_BONUS_TIME_SUM} ${BONUS_TIME} | awk '{print $1 + $2}')
+              L_RESULT_TIME_SUM=$(echo ${L_RESULT_TIME_SUM} ${RESULT_TIME} | awk '{print $1 + $2}')
               echo $(( L_GOAL_COUNTER++ ))
             elif [ "${COURSE_UPPER}" == "R" ]; then
-              R_GOAL_TIME_SUM+=$(echo ${R_GOAL_TIME_SUM} ${GOAL_TIME} | awk '{print $1 + $2}')
-              R_BONUS_TIME_SUM+=$(echo ${R_BONUS_TIME_SUM} ${BONUS_TIME} | awk '{print $1 + $2}')
-              R_RESULT_TIME_SUM+=$(echo ${R_RESULT_TIME_SUM} ${RESULT_TIME} | awk '{print $1 + $2}')
+              R_GOAL_TIME_SUM=$(echo ${R_GOAL_TIME_SUM} ${GOAL_TIME} | awk '{print $1 + $2}')
+              R_BONUS_TIME_SUM=$(echo ${R_BONUS_TIME_SUM} ${BONUS_TIME} | awk '{print $1 + $2}')
+              R_RESULT_TIME_SUM=$(echo ${R_RESULT_TIME_SUM} ${RESULT_TIME} | awk '{print $1 + $2}')
               echo $(( R_GOAL_COUNTER++ ))
             fi
           fi

--- a/.github/workflows/sim-test.yaml
+++ b/.github/workflows/sim-test.yaml
@@ -220,16 +220,12 @@ jobs:
             jq -s '.' | \
             jq 'max_by(.TIME)' > ${TMP_JSON_FILE}
 
-          echo "[DEBUG 00] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
-
           # ビンゴエリアの最終結果を集計する
           BLOCK_YUKOIDO=$(jq -r '.BLOCK_YUKOIDO' ${TMP_JSON_FILE})
           POWER_SPOT_YUKOIDO=$(jq -r '.BLOCK_YUKOIDOP' ${TMP_JSON_FILE})
           CENTER_BLOCK_YUKOIDO=$(jq -r '.BLOCK_YUKOIDOC' ${TMP_JSON_FILE})
           BLOCK_BINGO=$(jq -r '.BLOCK_BINGO' ${TMP_JSON_FILE})
           POWERS_POT_BINGO=$(jq -r '.BLOCK_BINGOP' ${TMP_JSON_FILE})
-
-          echo "[DEBUG 01] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
 
           # ボーナスタイムの計算
           BLOCK_YUKOIDO_BONUS_TIME=$(echo ${BLOCK_YUKOIDO} | awk '{print $1 / 2}')
@@ -244,8 +240,6 @@ jobs:
                             ${POWER_SPOT_BINGO_BONUS_TIME} \
                             | awk '{print $1 + $2 + $3 + $4 + $5}')
 
-          echo "[DEBUG 02] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
-
           # 各ゲートを通過したかどうかの確認
           PASSED_START_GATE=$(cat ${TEST_RESULT_DIR_ROOT}/${LOG_FILE} | \
                               grep -coE '\[ launcher: ((left)|(right)): passed Start Gate \]' || :)
@@ -256,30 +250,22 @@ jobs:
           PASSED_GALE_GATE=$(cat ${TEST_RESULT_DIR_ROOT}/${LOG_FILE} | \
                               grep -coE '\[ launcher: ((left)|(right)): GOAL!  Goal Time: ([0-9]*\.?[0-9]*) \]' || :)
 
-          echo "[DEBUG 03] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
-
           # 走行時間の取得 (ゴールゲートの通過)、リザルトタイムの算出
           if [ "${PASSED_GALE_GATE}" == '0' ]; then
-            echo "[DEBUG 03.1] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
             GOAL_TIME='None'
             RESULT_TIME='None'
           else
-            echo "[DEBUG 03.2] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
             GOAL_TIME="$(cat ${TEST_RESULT_DIR_ROOT}/${LOG_FILE} | \
                           grep -oE '\[ launcher: ((left)|(right)): GOAL!  Goal Time: ([0-9]*\.?[0-9]*) \]' | \
                           grep -oE '[0-9]*\.?[0-9]*')"
             
-            echo "[DEBUG 03.3] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
             # リザルトタイムの計算
             RESULT_TIME=$(echo ${GOAL_TIME} ${BONUS_TIME} | awk '{print $1 - $2}')
 
-            echo "[DEBUG 03.4] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
             # ベストタイムの更新
             if [ "$(echo "${RESULT_TIME} < ${BEST_RESULT_TIME}" | bc)" -eq 1 ]; then
               BEST_RESULT_TIME=${RESULT_TIME}
             fi
-
-            echo "[DEBUG 04] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
 
             # 集計用変数の更新
             if [ "${COURSE_UPPER}" == "L" ]; then
@@ -295,16 +281,12 @@ jobs:
             fi
           fi
 
-          echo "[DEBUG 05] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
-          
           # 走行回数カウンターの更新
           if [ "${COURSE_UPPER}" == "L" ]; then
             echo $(( L_COUNTER++ ))
           elif [ "${COURSE_UPPER}" == "R" ]; then
             echo $(( R_COUNTER++ ))
           fi
-
-          echo "[DEBUG 06] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
 
           # コメント用集計結果の計算
           L_GOAL_RATE=$(echo ${L_GOAL_COUNTER} ${L_COUNTER} | awk '{if($2>0){print $1 / $2 * 100}else{print 0}}')
@@ -323,16 +305,12 @@ jobs:
           LR_RESULT_TIME_AVG=$(echo ${L_RESULT_TIME_SUM} ${R_RESULT_TIME_SUM} ${L_GOAL_COUNTER} ${R_GOAL_COUNTER} | \
                               awk '{if(($3+$4)>0){print ($1 + $2) / ($3 + $4)}else{print 0}}')
 
-          echo "[DEBUG 07] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
-
           # コメントの作成
           MSG_RESULT+="|${i}|${COURSE_UPPER}|${GOAL_TIME}|${BONUS_TIME}|${RESULT_TIME}|"
-
           MSG_DETAIL+="|${i}|${PASSED_START_GATE}|${PASSED_GATE_1}|${PASSED_GATE_2}|${GOAL_TIME}"
           MSG_DETAIL+="|${BLOCK_YUKOIDO_BONUS_TIME}|${POWER_SPOT_YUKOIDO_BONUS_TIME}"
           MSG_DETAIL+="|${CENTER_BLOCK_YUKOIDO_BONUS_TIME}|${BLOCK_BINGO_BONUS_TIME}"
           MSG_DETAIL+="|${POWER_SPOT_BINGO_BONUS_TIME}|${BONUS_TIME}|${RESULT_TIME}|"
-
           if [ "${COURSE_UPPER}" == "L" ]; then
             MSG_RESULT+="${BLOCK_COORDINATE_L}|"
             MSG_DETAIL+="${BLOCK_COORDINATE_L}|"
@@ -377,15 +355,11 @@ jobs:
                               jq ".workflow_runs[] | select( .name == \"${GITHUB_WORKFLOW}\" ) | .id" | \
                               wc -l)
 
-          echo "[DEBUG 08] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
-
           # ループ終了時の片づけ
           if [[ "${i}" == "${MAX_SIM_TIME}" || "${QUEUED_JOB_NUM}" != "0" ]]; then
             MSG_TAIL=""
             i=${MAX_SIM_TIME}
           fi
-
-          echo "[DEBUG 08] HOGEHGOHEOHGOEHGOHEOGHEOGHEHGOEH"
 
           # プルリクコメントのアップデート
           MSG="${MSG_RESULT}${MSG_DETAIL}${MSG_DETAIL_TAIL}${MSG_SUMMARY_HEAD}${MSG_SUMMARY}${MSG_SUMMARY_DETAIL_HEAD}${MSG_SUMMARY_DETAIL}${MSG_SUMMARY_DETAIL_TAIL}${MSG_TAIL}"


### PR DESCRIPTION
# チェックリスト

- ~~[ ] clang-format している~~
- ~~[ ] コーディング規約に準じている~~
- [X] チケットの完了条件を満たしている

# 変更点
- CIのシミュレータテストにおいて、ビンゴエリアの結果を取得・反映できるようになった
- シミュレータテストを左右のコースで複数回実行できるようになった
- GitHub の API を使うことによって、CIのテスト結果をコメントを逐次アップデートする形で通知することが出来るようになった
- テスト実行中に他のシミュレータテストのリクエストが来た場合、それ以降のテストを実行しないようにした
- テスト終了時にキャプチャファイルなどを都度削除し、ディスク使用量の削減に努めた

# 動作テスト
このプルリクの結果を参照すること。

## 動作テストの詳解
以下、時系列順
1. プルリクエストを出したことにより、シミュレータテストが開始される
2. 上記のシミュレータテストが実行されている途中で、新たな変更をPushしたことにより新たなシミュレータテストのリクエストが発生するが、マシンは1台しかないため待ち状態が発生する
3. すると、`1.`のシミュレータテストは待ち状態を検知し、以降のシミュレータテストを中断する【1つ目の結果】
4. `2.`で待ち状態になっていたシミュレータテストが開始される
5. 上記のテストの途中で他のシミュレータテストのリクエストが発生しなかったため、最大試行回数(4回)分のテストを行いテストを終了する【2つ目の結果】
（以下略）

# その他
~~動作テストが完了次第、シミュレータの最大試行回数を20回に設定予定（現在は簡単のため4回）。~~

## ワンポイント
### Slackへ転送されるシミュレータテストの結果に関して
何故か知らないけど、GitHubのコメント（シミュレータテストの結果）をアップデートするとSlackへ転送されたコメントもアップデートされる模様

### 状態の通知
シミュレータテストが実行中の場合、当該コメントに以下のように実行中である旨を記述している。
> :arrows_counterclockwise: Testing now... (2/20)

### シミュレータ用PCの使用率の向上
今まで、CIによるシミュレータテストは各々1回しかテストを行わなかっため、シミュレータ用PCの使用率が低いという問題があった。
そこで今回は、シミュレータテストの回数を増やすことによって使用率の向上を図った。

また、使用率の向上のために利便性を犠牲にしないために、実行待ちのリクエスト発生した場合は以降のテストを実行しないようにした。

そして、コメントのアップデート機能を用いて逐次シミュレータのテスト結果を確認できるようにした。