### PR TITLE
close #158 方向転換の精度調整

### DIFF
--- a/module/BingoMotion/BlockThrower.cpp
+++ b/module/BingoMotion/BlockThrower.cpp
@@ -20,7 +20,8 @@ void BlockThrower::setBlockThrow(bool isClockwise)
   double diffRightDistance;
   int leftPwm;
   int rightPwm;
-  double targetDistance = M_PI * TREAD * angle / 360;
+  const double _TREAD = TREAD - 8;
+  double targetDistance = M_PI * _TREAD * angle / 360;
   double targetLeftDistance;
   double targetRightDistance;
   int armPwm = 90;

--- a/module/BingoMotion/DirectionChanger.cpp
+++ b/module/BingoMotion/DirectionChanger.cpp
@@ -15,7 +15,7 @@ void DirectionChanger::changeDirection(int angle, bool isClockwise)
 {
   StraightRunner straightRunner;
   int rotatePwm = 30;
-  int targetDistance = 20;
+  int targetDistance = 10;
   int runPwm = 20;
 
   //回転方向を判定
@@ -27,17 +27,20 @@ void DirectionChanger::changeDirection(int angle, bool isClockwise)
 
   //エッジ切り替え
   if(lineTracer.getIsLeftEdge()) {
-    if((isClockwise && angle == 135) || (!isClockwise && angle == -45) || angle == -135 || angle == -90 || angle == 180) {
+    if((isClockwise && angle == 135) || (!isClockwise && angle == -45) || angle == -135
+       || angle == -90 || angle == 180) {
       lineTracer.setIsLeftEdge(false);
     }
   } else {
-    if((isClockwise && angle == 45) || (!isClockwise && angle == -135) || angle == 135 || angle == 90 || angle == 180) { 
+    if((isClockwise && angle == 45) || (!isClockwise && angle == -135) || angle == 135
+       || angle == 90 || angle == 180) {
       lineTracer.setIsLeftEdge(true);
     }
   }
 
   //色サークルに乗るまで直進(要調整)
   straightRunner.runStraightToDistance(targetDistance, runPwm);
+  straightRunner.runStraightToBlackWhite(runPwm);
 
   //白黒を判定するまで進む
   straightRunner.runStraightToBlackWhite(runPwm);

--- a/module/Motion/Rotation.cpp
+++ b/module/Motion/Rotation.cpp
@@ -16,7 +16,7 @@ Rotation::Rotation()
 //左回転
 void Rotation::rotateLeft(int angle, int pwm)
 {
-  const double _TREAD = TREAD - 3;  // 回頭距離の調整
+  const double _TREAD = TREAD - 8;  // 回頭距離の調整
   int leftSign = -1;
   int rightSign = 1;
   double targetDistance = M_PI * _TREAD * abs(angle) / 360;  //弧の長さ
@@ -63,7 +63,7 @@ void Rotation::rotateLeft(int angle, int pwm)
 //右回転
 void Rotation::rotateRight(int angle, int pwm)
 {
-  const double _TREAD = TREAD - 3;  // 回頭距離の調整
+  const double _TREAD = TREAD - 8;  // 回頭距離の調整
   int leftSign = 1;
   int rightSign = -1;
   double targetDistance = M_PI * _TREAD * abs(angle) / 360;  //弧の長さ

--- a/test/RotationTest.cpp
+++ b/test/RotationTest.cpp
@@ -25,7 +25,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 137.0;
+    double tread = 132.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -81,7 +81,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 137.0;
+    double tread = 132.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -108,7 +108,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 137.0;
+    double tread = 132.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -136,7 +136,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 137.0;
+    double tread = 132.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -181,7 +181,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 137.0;
+    double tread = 132.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -223,7 +223,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 137.0;
+    double tread = 132.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -250,7 +250,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 137.0;
+    double tread = 132.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 
@@ -278,7 +278,7 @@ namespace etrobocon2021_test {
     double leftMotorCount;
     double rightMotorCount;
     double targetDistance;
-    double tread = 137.0;
+    double tread = 132.0;
     double error = M_PI * tread / 360;  //誤差1度
     int angle, pwm;
 


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- 回頭動作のパラメータ調整
- 方向転換後に直進する処理を修正
- 投げ入れ設置時の回頭動作を修正

# 動作テスト

## 実験方法
投げ入れ設置、ピボットターン設置それぞれについて、「設置動作→方向転換→交点間移動」を3連続で行い、正常に動作できるかを確認する。

## 実験データ

テストルート完走率(3連速で設置できた率)
| 動作 |  修正前  |  修正後  |
| ---- | ---- | ---- |
|  投げ入れ設置  |  50%  |  60%  |
|  ピボット設置  |  0%  |  44%  |

## 実験結果
### 投げ入れ設置 成功例

https://user-images.githubusercontent.com/83441177/132138564-92bc7d2b-1510-4e2b-bb9a-49c5bafadf7d.mp4

### 投げ入れ設置 失敗例

https://user-images.githubusercontent.com/83441177/132138569-c7935c85-58fe-4b16-9d5a-8d0d7fa22c82.mp4

### ピボットターン設置 成功例

https://user-images.githubusercontent.com/83441177/132138590-a1ad7f19-3686-4b94-831c-08ae68f4846e.mp4

### ピボットターン設置 失敗例

https://user-images.githubusercontent.com/83441177/132138598-d8de6b82-47fb-408a-b099-93c19a56311c.mp4


## 添付資料
