### PR TITLE
close #189 黒ブロック運搬の精度調整

### DIFF
--- a/module/BingoMotion/BlackBlockCarrier.cpp
+++ b/module/BingoMotion/BlackBlockCarrier.cpp
@@ -11,58 +11,50 @@ void BlackBlockCarrier::carryBlackBlock()
   constexpr int RUN_CURVE_PWM = 50;
   constexpr int TARGET_BRIGHTNESS = 20;  //目標輝度
   const PidGain CURVE_GAIN(3, 1, 1);     //カーブのライントレースに使用するゲイン
-  const PidGain RUN_GAIN(1, 0.8, 1);     //直進のライントレースに使用するゲイン
-  const PidGain TO_FRONT_GAIN(0.2, 1, 1);
+  const PidGain RUN_GAIN(0.1, 0.8, 0.15);  //直進のライントレースに使用するゲイン
+  const PidGain BLUE_LINE_GAIN(0.2, 1, 0.5);  //青線上をライントレースする際に使用するゲイン
+  const PidGain TO_GREEN_LINE_GAIN(0.2, 1, 0.3);  //緑の円までライントレースする際に使用するゲイン
+  const PidGain LAST_LINE_GAIN(0.1, 0.1, 0.12);  //黒ブロックを取得するラインで使用するゲイン
   bool isLeftEdge = !IS_LEFT_COURSE;
   Rotation rotation;
   StraightRunner straightRunner;
   LineTracer lineTracer(isLeftEdge);
   Measurer measurer;
   Controller controller;
-  InCrossLeft inCrossLeft(lineTracer);
-  InCrossRight inCrossRight(lineTracer);
-
   //青の線を通過
-  lineTracer.run(250, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM, RUN_GAIN);
+  lineTracer.run(250, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM, BLUE_LINE_GAIN);
   //青の線まで
   lineTracer.run(650, TARGET_BRIGHTNESS, RUN_CURVE_PWM, CURVE_GAIN);
   //青の線を通過
-  lineTracer.run(350, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM, RUN_GAIN);
+  lineTracer.run(350, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM, BLUE_LINE_GAIN);
   //黄色の円まで
-  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM, RUN_GAIN);
+  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, RUN_GAIN);
   //黄色の円を通過
-  straightRunner.runStraightToDistance(120, RUN_STRAIGHT_PWM);
+  straightRunner.runStraightToDistance(120, RUN_STRAIGHT_PWM - 30);
   //緑の円まで
-  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM, RUN_GAIN);
-  //緑の円の中心まで移動
-  straightRunner.runStraightToDistance(40, RUN_STRAIGHT_PWM - 30);
-  //右に９０度回頭
-  IS_LEFT_COURSE ? rotation.rotateRight(90, 10) : rotation.rotateLeft(90, 10);
-  //黒線まで直進
-  straightRunner.runStraightToDistance(70, RUN_STRAIGHT_PWM - 60);
-  //黒ブロック手前まで直進
-  lineTracer.runToColor(TARGET_BRIGHTNESS, 30, RUN_GAIN);
-  //弧を描いて曲がる
-  double startDiff
-      = IS_LEFT_COURSE
-            ? Mileage::calculateWheelMileage(measurer.getLeftCount())
-                  - Mileage::calculateWheelMileage(measurer.getRightCount())
-            : Mileage::calculateWheelMileage(measurer.getRightCount())
-                  - Mileage::calculateWheelMileage(measurer.getLeftCount());  //開始時の差
-  while(IS_LEFT_COURSE ? Mileage::calculateWheelMileage(measurer.getRightCount()) + startDiff
-                             >= Mileage::calculateWheelMileage(measurer.getLeftCount()) - 220
-                       : Mileage::calculateWheelMileage(measurer.getLeftCount()) + startDiff
-                             >= Mileage::calculateWheelMileage(measurer.getRightCount()) - 220) {
-    //モータのPWM値をセット
-    controller.setRightMotorPwm(IS_LEFT_COURSE ? 41 : 58);
-    controller.setLeftMotorPwm(IS_LEFT_COURSE ? 58 : 41);
-    controller.sleep();
-  }
-  controller.stopMotor();
-
-  //ビンゴの中心まで直進
-  straightRunner.runStraightToDistance(320, RUN_STRAIGHT_PWM - 20);
+  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, TO_GREEN_LINE_GAIN);
+  //９０度ピボットターン
+  straightRunner.runStraightToDistance(10, RUN_STRAIGHT_PWM - 50);
+  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(90, 33) : rotation.turnForwardLeftPivot(90, 33);
+  //黒ブロック手前までライントレース
+  lineTracer.run(85, TARGET_BRIGHTNESS, 20, LAST_LINE_GAIN);
+  //センターマークの平行線上まで直進
+  straightRunner.runStraightToDistance(100, RUN_STRAIGHT_PWM - 50);
+  straightRunner.runStraightToDistance(100, RUN_STRAIGHT_PWM - 40);
+  straightRunner.runStraightToDistance(270, RUN_STRAIGHT_PWM - 30);
+  straightRunner.runStraightToDistance(75, RUN_STRAIGHT_PWM - 50);
+  controller.sleep(500);
+  // 90度ピボットターン
+  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(89, 33) : rotation.turnForwardLeftPivot(89, 33);
+  //センターマークまで直進する(黒→青→青→黒の順に認識する)
+  straightRunner.runStraightToDistance(70, RUN_STRAIGHT_PWM - 50);
+  straightRunner.runStraightToColor(RUN_STRAIGHT_PWM - 40, COLOR::BLACK);
+  straightRunner.runStraightToColor(RUN_STRAIGHT_PWM - 30, COLOR::BLUE);
+  straightRunner.runStraightToColor(RUN_STRAIGHT_PWM - 30, COLOR::BLUE);
+  straightRunner.runStraightToColor(RUN_STRAIGHT_PWM - 30, COLOR::BLACK);
+  straightRunner.runStraightToDistance(135, RUN_STRAIGHT_PWM - 50);
+  //タイヤの中心を黒線に合わせる
+  controller.sleep(500);
+  straightRunner.runStraightToColor(-20, COLOR::BLACK);
   straightRunner.runStraightToDistance(50, RUN_STRAIGHT_PWM - 60);
-  //黒のラインまで下がる
-  straightRunner.runStraightToDistance(85, -20);
 }

--- a/module/BingoMotion/BlackBlockCarrier.h
+++ b/module/BingoMotion/BlackBlockCarrier.h
@@ -11,15 +11,12 @@
 #include "LineTracer.h"
 #include "StraightRunner.h"
 #include "Controller.h"
-#include "InCrossLeft.h"
 #include "LineTraceArea.h"
-#include "InCrossRight.h"
 #include "Mileage.h"
 #include "Measurer.h"
 
 class BlackBlockCarrier {
  public:
- 
- static void carryBlackBlock();
+  static void carryBlackBlock();
 };
 #endif

--- a/module/Motion/StraightRunner.cpp
+++ b/module/Motion/StraightRunner.cpp
@@ -186,3 +186,63 @@ void StraightRunner::runStraightToBlackWhite(int pwm)
   // モータの停止
   controller.stopMotor();
 }
+
+// 指定した色を検出するまで直進する
+void StraightRunner::runStraightToColor(int pwm, COLOR destColor)
+{
+  // 直進前の走行距離
+  int initialRightMotorCount = measurer.getRightCount();
+  int initialLeftMotorCount = measurer.getLeftCount();
+  // 直進中の走行距離
+  int currentRightMotorCount = 0;
+  int currentLeftMotorCount = 0;
+  int currentDistance = 0;
+  int error = 0;                // 左右の回転数の誤差
+  Pid pid(1.2, 0.3, 0.001, 0);  // 左右の回転数を合わせるためのPID
+  int adjustment = 0;           // 左右の誤差の補正値
+
+  // 現在のpwm値
+  int currentPwm = 0;
+
+  // pwm値が0の際は、終了する。
+  if(pwm == 0) return;
+
+  while(true) {
+    // 現在のRGB値から色を識別する
+    COLOR color = ColorJudge::getColor(measurer.getRawColor());
+
+    // 白黒以外の色を検出した場合、直進終了
+    if(color == destColor) {
+      break;
+    }
+
+    //現在の距離を取得する
+    currentRightMotorCount = measurer.getRightCount();
+    currentLeftMotorCount = measurer.getLeftCount();
+    currentDistance = Mileage::calculateMileage(currentLeftMotorCount, currentRightMotorCount);
+
+    // PWM値を徐々に目標値に合わせる
+    if(currentPwm != pwm) {
+      // 調整距離毎にPWM値を加速値分だけ上げていく
+      currentPwm
+          = currentDistance / SECTION_DISTANCE * ACCELE_PWM + ACCELE_PWM * ((pwm > 0) ? 1 : -1);
+      if(std::abs(currentPwm) > std::abs(pwm)) {
+        currentPwm = pwm;
+      }
+    }
+
+    // 左右のモーターカウントを合わせるための補正値計算
+    error = (currentLeftMotorCount - initialLeftMotorCount)
+            - (currentRightMotorCount - initialRightMotorCount);
+    adjustment = static_cast<int>(pid.calculatePid(error));
+
+    // モータのPWM値をセット
+    controller.setLeftMotorPwm(currentPwm + adjustment);
+    controller.setRightMotorPwm(currentPwm - adjustment);
+
+    // 10ミリ秒待機
+    controller.sleep();
+  }
+  // モータの停止
+  controller.stopMotor();
+}

--- a/module/Motion/StraightRunner.h
+++ b/module/Motion/StraightRunner.h
@@ -39,6 +39,12 @@ class StraightRunner {
    */
   void runStraightToBlackWhite(int pwm);
 
+  /**
+   * 指定した色を検出するまで直進する関数
+   * @param pwm PWM値
+   */
+  void runStraightToColor(int pwm, COLOR destColor);
+
  private:
   // SECTION_DISTANCE毎にACCELE_PWMだけPWM値を上げる
   static constexpr int SECTION_DISTANCE = 10;  // 調整距離[mm]


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [ ] チケットの完了条件を満たしている

# 変更点
黒ブロックの設置動作を旋回設置から直進→ピボットターン→直進の動作に変更
# 動作テスト

## 実験方法
以下の要点に着目し、検証を行う。
- 黒ブロックを設置できているか
- 設置動作後にビンゴ動作を行えるか
## 実験データ
黒ブロックを設置できる確率 75%
黒ブロックを設置できるかつ設置後にビンゴ動作を行える確率 62%
## 添付資料
### 成功例(黒ブロックを設置できるかつ設置後にビンゴ動作を行える)
https://user-images.githubusercontent.com/62526141/132176139-5d2f6fa0-38f6-4916-8166-eeafa025abd0.mp4
### 失敗例1(黒ブロックを設置できない)
https://user-images.githubusercontent.com/62526141/132176270-5bb2eab2-e4b3-4352-80a7-4b5f02322b32.mp4
### 失敗例2(黒ブロックを設置後にビンゴ動作を行えない)
https://user-images.githubusercontent.com/62526141/132176389-63c0ec73-01b0-49e8-b496-4975a8022931.mp4






