### PR TITLE
ticket #193 パラメータ調整

### DIFF
--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -21,11 +21,11 @@ const std::array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::
 const std::array<SectionParam, LineTraceArea::RIGHT_SECTION_SIZE> LineTraceArea::RIGHT_COURSE_INFO
     = { SectionParam{ 150, 12, 60, PidGain(0.2, 0.1, 0.1) },
         SectionParam{ 1445, 12, 100, PidGain(3.5, 1, 1) },
-        SectionParam{ 670, 12, 80, PidGain(1.6, 1.05, 1.3) },
+        SectionParam{ 670, 12, 80, PidGain(1.7, 0.8, 0.8) },  //(1.6, 1.05, 1.3)
         SectionParam{ 600, 12, 100, PidGain(3.3, 1, 1) },
-        SectionParam{ 580, 12, 80, PidGain(1.6, 0.67, 0.65) },
+        SectionParam{ 580, 12, 80, PidGain(1.6, 0.67, 0.6) },
         SectionParam{ 1450, 12, 100, PidGain(4, 0.3, 0.3) },
-        SectionParam{ 400, 12, 60, PidGain(5, 1.3, 0.15) },
+        SectionParam{ 400, 12, 60, PidGain(6, 2, 0.5) },
         SectionParam{ 700, 12, 100, PidGain(3, 1, 1.8) } };
 
 void LineTraceArea::runLineTraceArea()

--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -10,10 +10,10 @@
 const std::array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::LEFT_COURSE_INFO
     = { SectionParam{ 150, 12, 60, PidGain(0.1, 0.8, 0.1) },
         SectionParam{ 1445, 12, 100, PidGain(3.5, 1, 1) },
-        SectionParam{ 670, 12, 80, PidGain(1.3, 0.83, 1.3) },
+        SectionParam{ 670, 12, 80, PidGain(1.5, 0.83, 1.3) },
         SectionParam{ 600, 12, 100, PidGain(3.3, 1, 1) },
-        SectionParam{ 580, 12, 80, PidGain(0.95, 0.67, 0.66) },
-        SectionParam{ 1450, 12, 100, PidGain(4, 0.3, 0.3) },
+        SectionParam{ 580, 12, 80, PidGain(1.5, 0.67, 0.66) },
+        SectionParam{ 1450, 12, 100, PidGain(3, 0.3, 0.3) },
         SectionParam{ 400, 12, 60, PidGain(4.1, 1.2, 0.1) },
         SectionParam{ 700, 12, 100, PidGain(3, 1, 1.8) } };
 

--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -10,22 +10,22 @@
 const std::array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::LEFT_COURSE_INFO
     = { SectionParam{ 150, 12, 60, PidGain(0.1, 0.8, 0.1) },
         SectionParam{ 1445, 12, 100, PidGain(3.5, 1, 1) },
-        SectionParam{ 670, 12, 80, PidGain(1.5, 0.83, 1.3) },
-        SectionParam{ 600, 12, 100, PidGain(3.3, 1, 1) },
-        SectionParam{ 580, 12, 80, PidGain(1.5, 0.67, 0.66) },
+        SectionParam{ 670, 12, 80, PidGain(1.6, 0.83, 1.3) },
+        SectionParam{ 600, 12, 100, PidGain(2, 1, 1) },
+        SectionParam{ 580, 12, 80, PidGain(1.6, 0.67, 0.66) },
         SectionParam{ 1450, 12, 100, PidGain(3, 0.3, 0.3) },
-        SectionParam{ 400, 12, 60, PidGain(4.1, 1.2, 0.1) },
+        SectionParam{ 400, 12, 60, PidGain(5, 1.2, 0.1) },
         SectionParam{ 700, 12, 100, PidGain(3, 1, 1.8) } };
 
 // Rコースの情報を初期化する
 const std::array<SectionParam, LineTraceArea::RIGHT_SECTION_SIZE> LineTraceArea::RIGHT_COURSE_INFO
     = { SectionParam{ 150, 12, 60, PidGain(0.2, 0.1, 0.1) },
         SectionParam{ 1445, 12, 100, PidGain(3.5, 1, 1) },
-        SectionParam{ 670, 12, 80, PidGain(1.25, 1.05, 1.3) },
+        SectionParam{ 670, 12, 80, PidGain(1.6, 1.05, 1.3) },
         SectionParam{ 600, 12, 100, PidGain(3.3, 1, 1) },
-        SectionParam{ 580, 12, 80, PidGain(0.95, 0.675, 0.65) },
+        SectionParam{ 580, 12, 80, PidGain(1.6, 0.67, 0.65) },
         SectionParam{ 1450, 12, 100, PidGain(4, 0.3, 0.3) },
-        SectionParam{ 400, 12, 60, PidGain(4.2, 1.3, 0.15) },
+        SectionParam{ 400, 12, 60, PidGain(5, 1.3, 0.15) },
         SectionParam{ 700, 12, 100, PidGain(3, 1, 1.8) } };
 
 void LineTraceArea::runLineTraceArea()


### PR DESCRIPTION
# チェックリスト

- [ ] clang-format している
- [ ] コーディング規約に準じている
- [ ] チケットの完了条件を満たしている

# 変更点
ライントレースエリアのPID
# 動作テスト

## 実験方法

## 実験データ
- Lコース

| 番号 | 全体の明るさ | 影の方向 | スポットライトLの明るさ | スポットライトRの明るさ | コース | 走行時間 | 設定ファイル名 |
| ---- | ----------- | ------- | --------------------- | --------------------- | ------ | ------- | ------------- |
| 1 | 2 | 1 | 1 | 1 | Left | 17.216 | sim-settings/l/01.json |
| 2 | 2 | 1 | 1 | 1 | Left | 17.166 | sim-settings/l/02.json |
| 3 | 2 | 1 | 1 | 1 | Left | 17.266 | sim-settings/l/03.json |
| 4 | 2 | 1 | 1 | 1 | Left | 17.199 | sim-settings/l/04.json |
| 5 | 2 | 1 | 1 | 1 | Left | 17.316 | sim-settings/l/05.json |
| 6 | 2 | 1 | 1 | 1 | Left | 17.249 | sim-settings/l/06.json |
| 7 | 2 | 1 | 1 | 1 | Left | 17.249 | sim-settings/l/07.json |
| 8 | 2 | 1 | 1 | 1 | Left | 17.199 | sim-settings/l/08.json |
| 9 | 2 | 1 | 1 | 1 | Left | 17.233 | sim-settings/l/09.json |
| 10 | 2 | 1 | 1 | 1 | Left | 17.316 | sim-settings/l/10.json |

- Rコース

| 番号 | 全体の明るさ | 影の方向 | スポットライトLの明るさ | スポットライトRの明るさ | コース | 走行時間 | 設定ファイル名 |
| ---- | ----------- | ------- | --------------------- | --------------------- | ------ | ------- | ------------- |
| 1 | 2 | 1 | 1 | 1 | Right | 17.199 | sim-settings/r/01.json |
| 2 | 2 | 1 | 1 | 1 | Right | 17.283 | sim-settings/r/02.json |
| 3 | 2 | 1 | 1 | 1 | Right | 17.333 | sim-settings/r/03.json |
| 4 | 2 | 1 | 1 | 1 | Right | 17.249 | sim-settings/r/04.json |
| 5 | 2 | 1 | 1 | 1 | Right | 17.283 | sim-settings/r/05.json |
| 6 | 2 | 1 | 1 | 1 | Right | 17.183 | sim-settings/r/06.json |
| 7 | 2 | 1 | 1 | 1 | Right | None | sim-settings/r/07.json |
| 8 | 2 | 1 | 1 | 1 | Right | 17.233 | sim-settings/r/08.json |
| 9 | 2 | 1 | 1 | 1 | Right | 17.266 | sim-settings/r/09.json |
| 10 | 2 | 1 | 1 | 1 | Right | 17.249 | sim-settings/r/10.json |

## 実験結果
- Lコース

| 走行エリア平均 | 成功率 |
| ------------- | ----- |
| 17.241 [s] (n=10)    | 100.000 [%] (n=10) |


- Rコース

| 走行エリア平均 | 成功率 |
| ------------- | ----- |
| 17.253 [s] (n=9)    | 90.000 [%] (n=10) |

## CIシミュレータテスト結果（7日20時現在）

成功率 91% (91/100) 

## 試走会結果（7日20時現在）

成功率 87.5% (14/16) 

## 添付資料
