### PR TITLE
試走会　最新の状態をまとめたもの

### DIFF
--- a/module/BingoMotion/BlackBlockCarrier.cpp
+++ b/module/BingoMotion/BlackBlockCarrier.cpp
@@ -10,10 +10,10 @@ void BlackBlockCarrier::carryBlackBlock()
   constexpr int RUN_STRAIGHT_PWM = 80;
   constexpr int RUN_CURVE_PWM = 50;
   constexpr int TARGET_BRIGHTNESS = 20;  //目標輝度
-  const PidGain CURVE_GAIN(3, 1, 1);     //カーブのライントレースに使用するゲイン
+  const PidGain CURVE_GAIN(0.3, 1, 0.3);     //カーブのライントレースに使用するゲイン
   const PidGain RUN_GAIN(0.1, 0.8, 0.15);  //直進のライントレースに使用するゲイン
-  const PidGain BLUE_LINE_GAIN(0.2, 1, 0.4);  //青線上をライントレースする際に使用するゲイン
-  const PidGain TO_GREEN_LINE_GAIN(0.15, 1, 0.2);  //緑の円までライントレースする際に使用するゲイン
+  const PidGain BLUE_LINE_GAIN(0.2, 1, 0.15);  //青線上をライントレースする際に使用するゲイン
+  const PidGain TO_GREEN_LINE_GAIN(0.2, 1, 0.2);  //緑の円までライントレースする際に使用するゲイン
   const PidGain LAST_LINE_GAIN(0.1, 0.1, 0.12);  //黒ブロックを取得するラインで使用するゲイン
   bool isLeftEdge = !IS_LEFT_COURSE;
   Rotation rotation;
@@ -22,7 +22,7 @@ void BlackBlockCarrier::carryBlackBlock()
   Measurer measurer;
   Controller controller;
   //青の線までライントレース
-  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 50, RUN_GAIN);
+  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, RUN_GAIN);
   //青の線を通過
   lineTracer.run(140, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 30, BLUE_LINE_GAIN);
   //青の線まで
@@ -38,18 +38,17 @@ void BlackBlockCarrier::carryBlackBlock()
   lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, TO_GREEN_LINE_GAIN);
   //９０度ピボットターン
   straightRunner.runStraightToDistance(10, RUN_STRAIGHT_PWM - 50);
-  controller.sleep(500);
   IS_LEFT_COURSE ? rotation.turnForwardRightPivot(90, 33) : rotation.turnForwardLeftPivot(90, 33);
   //黒ブロック手前までライントレース
   lineTracer.run(85, TARGET_BRIGHTNESS, 20, LAST_LINE_GAIN);
   //センターマークの平行線上まで直進
   straightRunner.runStraightToDistance(100, RUN_STRAIGHT_PWM - 50);
   straightRunner.runStraightToDistance(100, RUN_STRAIGHT_PWM - 40);
-  straightRunner.runStraightToDistance(290, RUN_STRAIGHT_PWM - 30);
+  straightRunner.runStraightToDistance(240, RUN_STRAIGHT_PWM - 30);
   straightRunner.runStraightToDistance(75, RUN_STRAIGHT_PWM - 50);
-  controller.sleep(500);
   // 90度ピボットターン
   IS_LEFT_COURSE ? rotation.turnForwardRightPivot(89, 33) : rotation.turnForwardLeftPivot(89, 33);
+  controller.sleep(200);
   //センターマークまで直進する(黒→青→青→黒の順に認識する)
   straightRunner.runStraightToDistance(70, RUN_STRAIGHT_PWM - 50);
   straightRunner.runStraightToColor(RUN_STRAIGHT_PWM - 40, COLOR::BLACK);
@@ -61,5 +60,5 @@ void BlackBlockCarrier::carryBlackBlock()
   controller.sleep(500);
   straightRunner.runStraightToColor(-20, COLOR::BLACK);
   controller.sleep(200);
-  straightRunner.runStraightToDistance(65, RUN_STRAIGHT_PWM - 60);
+  straightRunner.runStraightToDistance(50, RUN_STRAIGHT_PWM - 60);
 }

--- a/module/BingoMotion/BlackBlockCarrier.cpp
+++ b/module/BingoMotion/BlackBlockCarrier.cpp
@@ -26,24 +26,27 @@ void BlackBlockCarrier::carryBlackBlock()
   lineTracer.run(200, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 20, PidGain(0.16, 0.8, 0.15));
   //黄色の円まで
   lineTracer.run(200, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 20, PidGain(0.12, 0.8, 0.15));
-  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, PidGain(0.1, 0.8, 0.14));
+  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, PidGain(0.15, 0.8, 0.2));
   //黄色の円を通過
   straightRunner.runStraightToDistance(120, RUN_STRAIGHT_PWM - 30);
   //緑の円まで
-  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, PidGain(0.14, 1, 0.2));
+  lineTracer.run(300, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 30, PidGain(0.12, 0.8, 0.2));
+  lineTracer.run(100, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 45, PidGain(0.12, 0.8, 0.15));
+  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 60, PidGain(0.1, 1, 0.13));
   //９０度ピボットターン
+  straightRunner.runStraightToDistance(16, RUN_STRAIGHT_PWM - 60);
   controller.sleep(300);
-  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(91, 33) : rotation.turnForwardLeftPivot(91, 33);
+  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(91.7, 33) : rotation.turnForwardLeftPivot(91.7, 33);
   //黒ブロック手前までライントレース
-  lineTracer.run(85, TARGET_BRIGHTNESS, 20, PidGain(0.11, 0.8, 0.16));
+  lineTracer.run(85, TARGET_BRIGHTNESS, 20, PidGain(0.12, 0.1, 0.12));
   //センターマークの平行線上まで直進
   straightRunner.runStraightToDistance(100, RUN_STRAIGHT_PWM - 50);
   straightRunner.runStraightToDistance(100, RUN_STRAIGHT_PWM - 40);
-  straightRunner.runStraightToDistance(230, RUN_STRAIGHT_PWM - 30);
+  straightRunner.runStraightToDistance(240, RUN_STRAIGHT_PWM - 30);
   straightRunner.runStraightToDistance(75, RUN_STRAIGHT_PWM - 50);
   controller.sleep(100);
   // 90度ピボットターン
-  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(91, 33) : rotation.turnForwardLeftPivot(91, 33);
+  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(91.5, 33) : rotation.turnForwardLeftPivot(91.5, 33);
   controller.sleep(200);
   //センターマークまで直進する(黒→青→青→黒の順に認識する)
   straightRunner.runStraightToDistance(70, RUN_STRAIGHT_PWM - 50);
@@ -56,5 +59,5 @@ void BlackBlockCarrier::carryBlackBlock()
   controller.sleep(500);
   straightRunner.runStraightToColor(-20, COLOR::BLACK);
   controller.sleep(200);
-  straightRunner.runStraightToDistance(50, RUN_STRAIGHT_PWM - 60);
+  straightRunner.runStraightToDistance(40, RUN_STRAIGHT_PWM - 60);
 }

--- a/module/BingoMotion/BlackBlockCarrier.cpp
+++ b/module/BingoMotion/BlackBlockCarrier.cpp
@@ -10,11 +10,6 @@ void BlackBlockCarrier::carryBlackBlock()
   constexpr int RUN_STRAIGHT_PWM = 80;
   constexpr int RUN_CURVE_PWM = 50;
   constexpr int TARGET_BRIGHTNESS = 20;  //目標輝度
-  const PidGain CURVE_GAIN(0.3, 1, 0.3);     //カーブのライントレースに使用するゲイン
-  const PidGain RUN_GAIN(0.1, 0.8, 0.15);  //直進のライントレースに使用するゲイン
-  const PidGain BLUE_LINE_GAIN(0.2, 1, 0.15);  //青線上をライントレースする際に使用するゲイン
-  const PidGain TO_GREEN_LINE_GAIN(0.2, 1, 0.2);  //緑の円までライントレースする際に使用するゲイン
-  const PidGain LAST_LINE_GAIN(0.1, 0.1, 0.12);  //黒ブロックを取得するラインで使用するゲイン
   bool isLeftEdge = !IS_LEFT_COURSE;
   Rotation rotation;
   StraightRunner straightRunner;
@@ -22,32 +17,33 @@ void BlackBlockCarrier::carryBlackBlock()
   Measurer measurer;
   Controller controller;
   //青の線までライントレース
-  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, RUN_GAIN);
+  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, PidGain(0.1, 0.8, 0.12));
   //青の線を通過
-  lineTracer.run(140, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 30, BLUE_LINE_GAIN);
+  lineTracer.run(140, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 30, PidGain(0.12, 0.8, 0.12));
   //青の線まで
-  lineTracer.run(660, TARGET_BRIGHTNESS, RUN_CURVE_PWM, CURVE_GAIN);
+  lineTracer.run(780, TARGET_BRIGHTNESS, RUN_CURVE_PWM, PidGain(0.4, 0.8, 0.2));
   //青の線を通過
-  lineTracer.run(210, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 15, BLUE_LINE_GAIN);
+  lineTracer.run(200, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 20, PidGain(0.16, 0.8, 0.15));
   //黄色の円まで
-  lineTracer.run(150, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 20, RUN_GAIN);
-  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, RUN_GAIN);
+  lineTracer.run(200, TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 20, PidGain(0.12, 0.8, 0.15));
+  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, PidGain(0.1, 0.8, 0.14));
   //黄色の円を通過
   straightRunner.runStraightToDistance(120, RUN_STRAIGHT_PWM - 30);
   //緑の円まで
-  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, TO_GREEN_LINE_GAIN);
+  lineTracer.runToColor(TARGET_BRIGHTNESS, RUN_STRAIGHT_PWM - 40, PidGain(0.14, 1, 0.2));
   //９０度ピボットターン
-  straightRunner.runStraightToDistance(10, RUN_STRAIGHT_PWM - 50);
-  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(90, 33) : rotation.turnForwardLeftPivot(90, 33);
+  controller.sleep(300);
+  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(91, 33) : rotation.turnForwardLeftPivot(91, 33);
   //黒ブロック手前までライントレース
-  lineTracer.run(85, TARGET_BRIGHTNESS, 20, LAST_LINE_GAIN);
+  lineTracer.run(85, TARGET_BRIGHTNESS, 20, PidGain(0.11, 0.8, 0.16));
   //センターマークの平行線上まで直進
   straightRunner.runStraightToDistance(100, RUN_STRAIGHT_PWM - 50);
   straightRunner.runStraightToDistance(100, RUN_STRAIGHT_PWM - 40);
-  straightRunner.runStraightToDistance(240, RUN_STRAIGHT_PWM - 30);
+  straightRunner.runStraightToDistance(230, RUN_STRAIGHT_PWM - 30);
   straightRunner.runStraightToDistance(75, RUN_STRAIGHT_PWM - 50);
+  controller.sleep(100);
   // 90度ピボットターン
-  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(89, 33) : rotation.turnForwardLeftPivot(89, 33);
+  IS_LEFT_COURSE ? rotation.turnForwardRightPivot(91, 33) : rotation.turnForwardLeftPivot(91, 33);
   controller.sleep(200);
   //センターマークまで直進する(黒→青→青→黒の順に認識する)
   straightRunner.runStraightToDistance(70, RUN_STRAIGHT_PWM - 50);

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -12,9 +12,9 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
 {
   double targetDistance = 4;
   double runPwm = 30;
-  double angle = 87.5;
-  int rotatePwm = 100;
-  int rotateAngle = 44;
+  double angle = 93;
+  int rotatePwm = 85;
+  int rotateAngle = 45;
   int backPwm = -10;
 
   LineTracer lineTracer(isClockwise);
@@ -23,6 +23,8 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
 
   //ピボットターンする
   if(isClockwise) {
+    straightRunner.runStraightToDistance(2, 40);
+
     inCrossRight.runRight();
     blockThrower.setBlockPivotThrow(isClockwise);
     rotation.rotateLeft(rotateAngle, rotatePwm);
@@ -30,6 +32,7 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
     straightRunner.runStraightToDistance(targetDistance, backPwm);
     rotation.rotateLeft(angle, rotatePwm);
   } else {
+    straightRunner.runStraightToDistance(2, 40);
     inCrossLeft.runLeft();
     blockThrower.setBlockPivotThrow(isClockwise);
     rotation.rotateRight(rotateAngle, rotatePwm);

--- a/module/BingoMotion/BlockThrower.cpp
+++ b/module/BingoMotion/BlockThrower.cpp
@@ -10,7 +10,7 @@ BlockThrower::BlockThrower() : BingoMotion(1, 1), TREAD(140), MIN_PWM(10) {}
 
 void BlockThrower::setBlockThrow(bool isClockwise)
 {
-  double runDistance = 105;
+  double runDistance = 100;
   int runPwm = 30;
   int angle = 45;
   int rotatePwm = 100;
@@ -76,7 +76,7 @@ void BlockThrower::setBlockThrow(bool isClockwise)
   ArmMotion::setKeepFlag(true);
 
   // 反動を打ち消すため直進する
-  straightRunner.runStraightToDistance(15.0, 20);
+  straightRunner.runStraightToDistance(13.0, 20);
 
   //モータの停止
   controller.stopMotor();
@@ -84,7 +84,7 @@ void BlockThrower::setBlockThrow(bool isClockwise)
 
 void BlockThrower::setBlockPivotThrow(bool isClockwise)
 {
-  double runDistance = 105;
+  double runDistance = 100;
   int runPwm = 30;
   int angle = 45;
   int rotatePwm = 100;
@@ -97,7 +97,7 @@ void BlockThrower::setBlockPivotThrow(bool isClockwise)
   double targetDistance = M_PI * TREAD * angle / 360;
   double targetLeftDistance;
   double targetRightDistance;
-  int armPwm = 70;
+  int armPwm = 50;
 
   // アームを水平にする処理を無効化
   ArmMotion::setKeepFlag(false);
@@ -145,6 +145,7 @@ void BlockThrower::setBlockPivotThrow(bool isClockwise)
   }
   // アームを水平にする処理を有効化
   ArmMotion::setKeepFlag(true);
+
   //モータの停止
   controller.stopMotor();
 }

--- a/module/BingoMotion/InCrossLeft.cpp
+++ b/module/BingoMotion/InCrossLeft.cpp
@@ -12,7 +12,7 @@ void InCrossLeft::runLeft(void)
 {
   int targetDistance = 10;
   int runPwm = 30;
-  int angle = 90;
+  int angle = 91;
   int turnPwm = 90;
 
   //ピボットターン後の位置を調整するため、直進する

--- a/module/BingoMotion/InCrossLeft.cpp
+++ b/module/BingoMotion/InCrossLeft.cpp
@@ -13,7 +13,7 @@ void InCrossLeft::runLeft(void)
   int targetDistance = 10;
   int runPwm = 30;
   int angle = 90;
-  int turnPwm = 100;
+  int turnPwm = 90;
 
   //ピボットターン後の位置を調整するため、直進する
   straightRunner.runStraightToDistance(targetDistance, runPwm);

--- a/module/BingoMotion/InCrossRight.cpp
+++ b/module/BingoMotion/InCrossRight.cpp
@@ -12,7 +12,7 @@ void InCrossRight::runRight(void)
 {
   int targetDistance = 10;
   int runPwm = 30;
-  int angle = 90;
+  int angle = 91;
   int rotatePwm = 90;
 
   //ピボットターン後の位置を調整するため、直進する

--- a/module/BingoMotion/InCrossRight.cpp
+++ b/module/BingoMotion/InCrossRight.cpp
@@ -13,7 +13,7 @@ void InCrossRight::runRight(void)
   int targetDistance = 10;
   int runPwm = 30;
   int angle = 90;
-  int rotatePwm = 100;
+  int rotatePwm = 90;
 
   //ピボットターン後の位置を調整するため、直進する
   straightRunner.runStraightToDistance(targetDistance, runPwm);

--- a/module/BingoMotion/ToCrossMotion.cpp
+++ b/module/BingoMotion/ToCrossMotion.cpp
@@ -14,7 +14,7 @@ void ToCrossMotion::runToCross(void)
 {
   int targetBrightness = 20;
   int pwm = 35;
-  PidGain gain(0.15, 1, 0.23);
+  PidGain gain(0.3, 1, 0.45);
   StraightRunner straightRunner;
 
   //白黒以外までライントレース

--- a/module/BingoMotion/ToCrossMotion.cpp
+++ b/module/BingoMotion/ToCrossMotion.cpp
@@ -12,9 +12,9 @@ ToCrossMotion::ToCrossMotion(LineTracer& _lineTracer) : BingoMotion(3, 3), lineT
 
 void ToCrossMotion::runToCross(void)
 {
-  int targetBrightness = 20;
-  int pwm = 35;
-  PidGain gain(0.3, 1, 0.45);
+  int targetBrightness = 12;
+  int pwm = 40;
+  PidGain gain(2.11, 1, 0.23);
   StraightRunner straightRunner;
 
   //白黒以外までライントレース

--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -10,22 +10,22 @@
 const std::array<SectionParam, LineTraceArea::LEFT_SECTION_SIZE> LineTraceArea::LEFT_COURSE_INFO
     = { SectionParam{ 150, 12, 60, PidGain(0.1, 0.8, 0.1) },
         SectionParam{ 1445, 12, 100, PidGain(3.5, 1, 1) },
-        SectionParam{ 670, 12, 80, PidGain(1.3, 0.83, 1.3) },
-        SectionParam{ 600, 12, 100, PidGain(3.3, 1, 1) },
-        SectionParam{ 580, 12, 80, PidGain(0.95, 0.67, 0.66) },
-        SectionParam{ 1450, 12, 100, PidGain(4, 0.3, 0.3) },
-        SectionParam{ 400, 12, 60, PidGain(4.1, 1.2, 0.1) },
+        SectionParam{ 670, 12, 80, PidGain(1.6, 0.83, 1.3) },
+        SectionParam{ 600, 12, 100, PidGain(2, 1, 1) },
+        SectionParam{ 580, 12, 80, PidGain(1.6, 0.67, 0.66) },
+        SectionParam{ 1450, 12, 100, PidGain(3, 0.3, 0.3) },
+        SectionParam{ 400, 12, 60, PidGain(5, 1.2, 0.1) },
         SectionParam{ 700, 12, 100, PidGain(3, 1, 1.8) } };
 
 // Rコースの情報を初期化する
 const std::array<SectionParam, LineTraceArea::RIGHT_SECTION_SIZE> LineTraceArea::RIGHT_COURSE_INFO
     = { SectionParam{ 150, 12, 60, PidGain(0.2, 0.1, 0.1) },
         SectionParam{ 1445, 12, 100, PidGain(3.5, 1, 1) },
-        SectionParam{ 670, 12, 80, PidGain(1.25, 1.05, 1.3) },
+        SectionParam{ 670, 12, 80, PidGain(1.7, 0.8, 0.8) },  //(1.6, 1.05, 1.3)
         SectionParam{ 600, 12, 100, PidGain(3.3, 1, 1) },
-        SectionParam{ 580, 12, 80, PidGain(0.95, 0.675, 0.65) },
+        SectionParam{ 580, 12, 80, PidGain(1.6, 0.67, 0.6) },
         SectionParam{ 1450, 12, 100, PidGain(4, 0.3, 0.3) },
-        SectionParam{ 400, 12, 60, PidGain(4.2, 1.3, 0.15) },
+        SectionParam{ 400, 12, 60, PidGain(6, 2, 0.5) },
         SectionParam{ 700, 12, 100, PidGain(3, 1, 1.8) } };
 
 void LineTraceArea::runLineTraceArea()

--- a/module/Motion/Rotation.cpp
+++ b/module/Motion/Rotation.cpp
@@ -126,7 +126,6 @@ void Rotation::turnForwardRightPivot(int angle, int pwm)
 
     controller.setLeftMotorPwm(leftPwm);
     controller.setRightMotorPwm(rightPwm);
-    controller.sleep();
 
     motorCount = (measurer.getLeftCount() + measurer.getRightCount()) / 2;
 
@@ -157,7 +156,6 @@ void Rotation::turnBackRightPivot(int angle, int pwm)
 
     controller.setLeftMotorPwm(-leftPwm);
     controller.setRightMotorPwm(rightPwm);
-    controller.sleep();
 
     controller.sleep();
   }
@@ -186,8 +184,6 @@ void Rotation::turnForwardLeftPivot(int angle, int pwm)
     controller.sleep();
 
     motorCount = ((measurer.getLeftCount()) + (measurer.getRightCount())) / 2;
-
-    controller.sleep();
   }
 
   controller.stopMotor();
@@ -213,7 +209,6 @@ void Rotation::turnBackLeftPivot(int angle, int pwm)
 
     controller.setLeftMotorPwm(leftPwm);
     controller.setRightMotorPwm(-rightPwm);
-    controller.sleep();
 
     motorCount = (abs(measurer.getLeftCount()) + abs(measurer.getRightCount())) / 2;
 


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
現在、上がっている全てのプルリクとビンゴ動作関連（ピボットターン設置、交点内移動）の調整を行ったもの。

# 動作テスト
試走会　
Ｌコース　ライントレースエリア　7/8成功　黒ブロック運搬0/8

黒ブロック運搬は、１０時現在、新しいものを試走会に出している。


## 実験方法

## 実験データ

|  修正前  |  修正後  |
| ---- | ---- |
|  -  |  -  |
|  -  |  -  |

## 実験結果

## 添付資料
