### PR TITLE
close #202 ピボットターン設置の後ブロックサークルの方向を向いて終了しても経路計画が行えるようにする

### DIFF
--- a/module/RoutePlanner/BlockSelector.cpp
+++ b/module/RoutePlanner/BlockSelector.cpp
@@ -171,14 +171,11 @@ BLOCK_ID BlockSelector::selectBlock()
   //最善と思われるブロックを運搬したものとしてロボットの向きと座標を更新する
   std::vector<std::pair<Coordinate, Direction>> bestSetRoute
       = routeCalculator.calculateRoute(bestBlockCoord, bestCircleCoord);
+  int routeSize = bestSetRoute.size();
+
   robot.setCoordinate(bestSetRoute[bestSetRoute.size() - 2].first);
-  if(abs(MotionConverter::calculateAngle(bestSetRoute[bestSetRoute.size() - 2].second,
-                                         bestSetRoute[bestSetRoute.size() - 1].second))
-     == 45) {
-    robot.setDirection(bestSetRoute[bestSetRoute.size() - 1].second);  //投げ入れ設置
-  } else {
-    robot.setDirection(bestSetRoute[bestSetRoute.size() - 2].second);  //ピボットターン設置
-  }
+  std::pair<Coordinate, Direction> Goal = bestSetRoute[routeSize - 1];
+  robot.setDirection(Goal.second);
   courseInfo.moveBlock(static_cast<CIRCLE_ID>(bestCircleNumber), bestBlockId);
 
   // 最良と思われる候補を返す

--- a/module/RoutePlanner/BlockSelector.cpp
+++ b/module/RoutePlanner/BlockSelector.cpp
@@ -52,7 +52,7 @@ BLOCK_ID BlockSelector::selectBlock()
   const int B_SIZE = static_cast<int>(BLOCK_ID::ID7) + 1;
   Coordinate currentCoordinate = robot.getCoordinate();  //現時点での走行体の座標
   Direction currentDirection = robot.getDirection();     //現時点での走行体の向き
-  printf("%d %d\n", currentCoordinate.x, currentCoordinate.y);
+
   // 最善と思われる運搬ブロックを探索する
   for(i = B_ZERO; i < B_SIZE; i++) {
     BLOCK_ID blockId = static_cast<BLOCK_ID>(i);
@@ -79,11 +79,9 @@ BLOCK_ID BlockSelector::selectBlock()
 
     robot.setDirection(route.back().second);  //ブロックを取得した後の向き
     robot.setCoordinate(route.back().first);  //ブロックを取得した後の座標
-    printf("%d %d -> %d %d\n", targetBlockCoord.x, targetBlockCoord.y, targetCircleCoord.x,
-           targetCircleCoord.y);
+
     route = routeCalculator.calculateRoute(targetBlockCoord, targetCircleCoord);
-    // if(route.front().first != targetBlockCoord || route.back().first != targetCircleCoord)
-    // continue;
+    if(route.front().first != targetBlockCoord || route.back().first != targetCircleCoord) continue;
 
     // 現在ブロックサークルに到着できない and 対象のブロックを運搬してもサークルが開放されない
     if(!arrivableCircles[targetCircleNumber] && !OPEN_CIRCLE_ID[i][targetCircleNumber]) continue;

--- a/module/RoutePlanner/RouteCalculator.h
+++ b/module/RoutePlanner/RouteCalculator.h
@@ -1,7 +1,7 @@
 /**
- * @file	RouteCalculator.h
- * @brief	経路計算クラス
- * @author	Hisataka-Hagiyama,uchyam
+ * @file  RouteCalculator.h
+ * @brief 経路計算クラス
+ * @author  Hisataka-Hagiyama,uchyam
  */
 
 #ifndef ROUTE_CALCULATOR_H
@@ -36,7 +36,7 @@ struct Route {
   Coordinate parent;    //親ノード
   int cost;             //このノードに到達するまでのコスト
   Direction direction;  //このノードでの向き
-  bool checked;         //経路復元の際にこのノードをチェックしたかどうか
+  bool checked;         //このノードを探索したかどうか
 
   //コンストラクタ
   Route() : parent(-1, -1), cost(0), direction(Direction::N), checked(false) {}
@@ -47,12 +47,14 @@ struct Route {
    * @param _parent 親ノード
    * @param _currentCost　このノードでのコスト
    * @param _direction このノードでの向き
+   * @param _checked このノードを探索したかどうか
    */
-  void setInfo(Coordinate _parent, int _currentCost, Direction _direction)
+  void setInfo(Coordinate _parent, int _currentCost, Direction _direction,bool _checked)
   {
     parent = _parent;
     cost = _currentCost;
     direction = _direction;
+    checked=_checked;
   }
 };
 
@@ -103,7 +105,7 @@ class RouteCalculator {
    * @param node 隣接ノードの情報
    * @param list オープンorクローズリスト
    */
-  void checkList(AstarInfo node, std::vector<AstarInfo>& list);
+  bool checkList(AstarInfo node, std::vector<AstarInfo>& list);
 
   /**
    * @fn int calculateManhattan(Coordinate coordinate);

--- a/module/RoutePlanner/RoutePlanner.cpp
+++ b/module/RoutePlanner/RoutePlanner.cpp
@@ -72,13 +72,7 @@ std::vector<std::vector<std::pair<Coordinate, Direction>>> RoutePlanner::planBin
     }
 
     // 走行体の方向を更新
-    if(std::abs(diffDirection) < 2) {
-      // 目標が前方にある場合、投げ入れ設置のため目標を向く
-      robot.setDirection(goal.second);
-    } else {
-      // 目標が後方にある場合、ピボット設置のため設置動作前の方向を向く
-      robot.setDirection(prevGoal.second);
-    }
+    robot.setDirection(goal.second);
 
     // ブロックを運搬したとして、ビンゴエリア情報を更新する
     courseInfo.moveBlock(targetCircleId, carryBlockId);

--- a/module/RoutePlanner/RoutePlanner.cpp
+++ b/module/RoutePlanner/RoutePlanner.cpp
@@ -53,7 +53,7 @@ std::vector<std::vector<std::pair<Coordinate, Direction>>> RoutePlanner::planBin
     }
     count++;
 
-    int routeSize = toCircleRoute.size();
+    int routeSize = static_cast<int>(toCircleRoute.size());
     // 運搬ブロックを設置する目標サークル
     std::pair<Coordinate, Direction> goal = toCircleRoute[routeSize - 1];
     // ブロック設置動作を開始する交点サークル

--- a/test/MotionConverterTest.cpp
+++ b/test/MotionConverterTest.cpp
@@ -41,14 +41,13 @@ namespace etrobocon2021_test {
     motionConverter.convertToMotion(minRoute);
     EXPECT_EQ(expectedMotion, MotionPerformer::motionLog);
     courseInfo.moveBlock(CIRCLE_ID::ID1, BLOCK_ID::ID3);
-    robot.setDirection(Direction::E);  //走行体の向きを更新
+    robot.setDirection(Direction::NW);  //走行体の向きを更新
 
     // BLOCK_ID::0の黄ブロックまで移動し、BLOCK_ID::0の黄ブロックをCIRCLE_ID::0の黄サークルまで移動させる
     start = { 4, 2 };
     goal = { 2, 0 };
     minRoute = route.calculateRoute(start, goal);
-    expectedMotion.push_back(MOTION::CDRC);
-    expectedMotion.push_back(MOTION::CDRC);
+    expectedMotion.push_back(MOTION::CDC);
     expectedMotion.push_back(MOTION::RTC);
     expectedMotion.push_back(MOTION::RL);
     expectedMotion.push_back(MOTION::RTC);
@@ -66,7 +65,7 @@ namespace etrobocon2021_test {
     robot.setDirection(Direction::SW);  //走行体の向きを更新
 
     // BLOCK_ID::4の黄ブロックまで移動し、BLOCK_ID::4の黄ブロックをCIRCLE_ID::4の黄サークルまで移動させる
-    start = { 2, 0 };
+    // start = { 2, 0 };
     goal = { 2, 4 };
     minRoute = route.calculateRoute(start, goal);
     expectedMotion.push_back(MOTION::CDRC);
@@ -107,14 +106,15 @@ namespace etrobocon2021_test {
     motionConverter.convertToMotion(minRoute);
     EXPECT_EQ(expectedMotion, MotionPerformer::motionLog);
     courseInfo.moveBlock(CIRCLE_ID::ID7, BLOCK_ID::ID7);
-    robot.setDirection(Direction::S);  //走行体の向きを更新
+    robot.setDirection(Direction::NE);  //走行体の向きを更新
 
     // BLOCK_ID::6の緑ブロックまで移動し、BLOCK_ID::6の緑ブロックをCIRCLE_ID::5の緑サークルまで移動させる
     start = { 4, 6 };
     goal = { 0, 6 };
     minRoute = route.calculateRoute(start, goal);
-    expectedMotion.push_back(MOTION::CDC);
-    expectedMotion.push_back(MOTION::CDC);
+    expectedMotion.push_back(MOTION::CDRC);
+    expectedMotion.push_back(MOTION::CDRC);
+    expectedMotion.push_back(MOTION::CDRC);
     expectedMotion.push_back(MOTION::RTC);
     expectedMotion.push_back(MOTION::RF);
     expectedMotion.push_back(MOTION::RTC);
@@ -129,14 +129,13 @@ namespace etrobocon2021_test {
     motionConverter.convertToMotion(minRoute);
     EXPECT_EQ(expectedMotion, MotionPerformer::motionLog);
     courseInfo.moveBlock(CIRCLE_ID::ID5, BLOCK_ID::ID6);
-    robot.setDirection(Direction::W);  //走行体の向きを更新
+    robot.setDirection(Direction::NE);  //走行体の向きを更新
 
     // BLOCK_ID::2の赤ブロックまで移動し、BLOCK_ID::2の赤ブロックをCIRCLE_ID::6の赤サークルまで移動させる
     start = { 0, 6 };
     goal = { 0, 2 };
     minRoute = route.calculateRoute(start, goal);
-    expectedMotion.push_back(MOTION::CDC);
-    expectedMotion.push_back(MOTION::CDC);
+    expectedMotion.push_back(MOTION::CDRC);
     expectedMotion.push_back(MOTION::RTC);
     expectedMotion.push_back(MOTION::RF);
     expectedMotion.push_back(MOTION::RTC);
@@ -203,7 +202,7 @@ namespace etrobocon2021_test {
     motionConverter.convertToMotion(minRoute);
     EXPECT_EQ(expectedMotion, MotionPerformer::motionLog);
     courseInfo.moveBlock(CIRCLE_ID::ID3, BLOCK_ID::ID1);
-    robot.setDirection(Direction::W);  //走行体の向きを更新
+    robot.setDirection(Direction::SW);  //走行体の向きを更新
     // この時点でフルビンゴ
   };
 
@@ -241,14 +240,13 @@ namespace etrobocon2021_test {
     motionConverter.convertToMotion(minRoute);
     EXPECT_EQ(expectedMotion, MotionPerformer::motionLog);
     courseInfo.moveBlock(CIRCLE_ID::ID1, BLOCK_ID::ID3);
-    robot.setDirection(Direction::W);  //走行体の向きを更新
+    robot.setDirection(Direction::NE);  //走行体の向きを更新
 
     // BLOCK_ID::0の黄ブロックまで移動し、BLOCK_ID::0の黄ブロックをCIRCLE_ID::0の黄サークルまで移動させる
     start = { 4, 2 };
     goal = { 2, 0 };
     minRoute = route.calculateRoute(start, goal);
-    expectedMotion.push_back(MOTION::CDC);
-    expectedMotion.push_back(MOTION::CDC);
+    expectedMotion.push_back(MOTION::CDRC);
     expectedMotion.push_back(MOTION::RTC);
     expectedMotion.push_back(MOTION::RR);
     expectedMotion.push_back(MOTION::RTC);


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- ピボットターン設置をし終わった際の走行体の向きをブロックサークルでの向きとする
- 閉路がある場合に探索が終わらなかったのを、一度訪れた座標を再度訪れないようにして閉路があっても探索が終わるように変更

**ピボットターン設置の動作を調整しないと本チケットは正常な動作を行うことができない**
## 実験方法
実際に経路を表示する/閉路があるパターンで動作を正常に終えるか動作を表示する

## 実験結果
**閉路による問題**
[探索が終わらず動作が始まらないパターン](https://etrobocon2021.moyashi.dev/01/results/2021-09-07/15-29-33/5211a69f3109f66d17fdc13eb1d8e46cfd865c63-16.mp4)
[本チケットのコードでの確認](https://user-images.githubusercontent.com/66076307/132348590-a5db34a9-29ae-438a-b939-5fd731189a76.mp4)

**ピボットターン設置後の方向転換の確認**
変更前
![oldRoute_L](https://user-images.githubusercontent.com/66076307/132354601-79657206-c3a9-47dc-84cc-32aed27a9c61.png)
![oldRoute_R](https://user-images.githubusercontent.com/66076307/132354604-a89525f4-9b28-4860-afce-dd1271de03d7.png)

変更後
![newRoute_L](https://user-images.githubusercontent.com/66076307/132354607-418caea8-1a20-468a-aadc-1913a97d1168.png)
![newRoute_R](https://user-images.githubusercontent.com/66076307/132354610-0e8cd5c0-4c33-4637-bb90-1715e400cbee.png)

## 添付資料
