### PR TITLE
close #210 経路計算でスタートノードの初期設定が間違っているのを修正

### DIFF
--- a/module/RoutePlanner/RouteCalculator.cpp
+++ b/module/RoutePlanner/RouteCalculator.cpp
@@ -21,7 +21,7 @@ std::vector<std::pair<Coordinate, Direction>> RouteCalculator::calculateRoute(Co
   int actualCost = 0;
   Route route[BINGO_SIZE][BINGO_SIZE];  //経路復元のための配列
   goalNode = goal;                      // ゴールノードをセット
-  route[start.x][start.y].setInfo(start, 0, robot.getDirection(), false);
+  route[start.x][start.y].setInfo(start, 0, robot.getDirection(), true);
   open.push_back(AstarInfo(start, route[start.x][start.y].cost + calculateManhattan(start)));
   while(!open.empty()) {
     //予測コストの小さい順にソートする

--- a/module/RoutePlanner/RouteCalculator.h
+++ b/module/RoutePlanner/RouteCalculator.h
@@ -47,7 +47,7 @@ struct Route {
    * @param _parent 親ノード
    * @param _currentCost　このノードでのコスト
    * @param _direction このノードでの向き
-   * @param _checked このノードを探索したかどうか
+   * @param _checked このノードを探索したかどうか(true:探索済み/false:未探索)
    */
   void setInfo(Coordinate _parent, int _currentCost, Direction _direction,bool _checked)
   {


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- スタートノードを未探索として探索を開始していたのを、探索開始時点で探索済みとするように変更(スタートノードの隣接ノードを探索した際に探索済みとしているため今までのコードでも探索は終わっていた）

## 添付資料
