### PR TITLE
close #214 ライントレースエリアの調整

### DIFF
--- a/module/LineTraceArea.h
+++ b/module/LineTraceArea.h
@@ -10,6 +10,11 @@
 #include "LineTracer.h"
 #include "Pid.h"
 
+#include "StraightRunner.h"
+#include "Mileage.h"
+#include "Measurer.h"
+#include "Controller.h"
+
 /**
  * Lコース/Rコース向けの設定を定義
  * デフォルトはLコース
@@ -31,10 +36,16 @@ struct SectionParam {
 class LineTraceArea {
  public:
   /**
-   *@fn static void RunLineTraceArea();
+   *@fn static void runLineTraceArea();
    *@brief ライントレースエリアを走行する
    */
   static void runLineTraceArea();
+
+  /**
+   *@fn static void runLineTraceAreaShortcut();
+   *@brief ライントレースエリアをショートカットしながら走行する
+   */
+  static void runLineTraceAreaShortcut();
 
  private:
   static const int LEFT_SECTION_SIZE = 8;   // Lコースの区間の数


### PR DESCRIPTION
# チェックリスト

- [ ] clang-format している
- [ ] コーディング規約に準じている
- [ ] チケットの完了条件を満たしている

# 変更点
- ライントレースエリアでのショートカットを追加

# 動作テスト

## 実験方法

## 実験データ

| 番号 | 全体の明るさ | 影の方向 | スポットライトLの明るさ | スポットライトRの明るさ | コース | 走行時間 | 設定ファイル名 |
| ---- | ----------- | ------- | --------------------- | --------------------- | ------ | ------- | ------------- |
| 1 | 2 | 1 | 1 | 1 | Left | 15.883 | sim-settings/l/01.json |
| 2 | 2 | 1 | 1 | 1 | Left | None | sim-settings/l/02.json |
| 3 | 2 | 1 | 1 | 1 | Left | 15.866 | sim-settings/l/03.json |
| 4 | 2 | 1 | 1 | 1 | Left | 15.916 | sim-settings/l/04.json |
| 5 | 2 | 1 | 1 | 1 | Left | 15.866 | sim-settings/l/05.json |
| 6 | 2 | 1 | 1 | 1 | Left | None | sim-settings/l/06.json |
| 7 | 2 | 1 | 1 | 1 | Left | 15.899 | sim-settings/l/07.json |
| 8 | 2 | 1 | 1 | 1 | Left | None | sim-settings/l/08.json |
| 9 | 2 | 1 | 1 | 1 | Left | 15.899 | sim-settings/l/09.json |
| 10 | 2 | 1 | 1 | 1 | Left | None | sim-settings/l/10.json |
### 集計結果
| 走行エリア平均 | 成功率 |
| ------------- | ----- |
| 15.888 [s] (n=6)    | 60.000 [%] (n=10) |

## 実験結果
走行タイム平均　17.247 [s] → 15.888 [s] 
成功率　95% → 60%

成功例

https://user-images.githubusercontent.com/83002406/137850972-9d5b30c6-ffd6-4980-975d-a8cebb6e0fda.mp4

失敗例

https://user-images.githubusercontent.com/83002406/137851046-f45645ee-5e4d-4891-9d6d-c9706f483fa5.mp4


## 添付資料
