### PR TITLE
close #217 右左折調整

### DIFF
--- a/module/BingoMotion/InCrossLeft.cpp
+++ b/module/BingoMotion/InCrossLeft.cpp
@@ -10,8 +10,8 @@ InCrossLeft::InCrossLeft(LineTracer& _lineTracer) : BingoMotion(10, 10), lineTra
 
 void InCrossLeft::runLeft(void)
 {
-  int targetDistance = 20;
-  int runPwm = 30;
+  int targetDistance = 25;
+  int runPwm = 40;
   int angle = 74;
   int turnPwm = 100;
 

--- a/module/BingoMotion/InCrossRight.cpp
+++ b/module/BingoMotion/InCrossRight.cpp
@@ -12,8 +12,8 @@ InCrossRight::InCrossRight(LineTracer& _lineTracer) : BingoMotion(10, 10), lineT
 
 void InCrossRight::runRight(void)
 {
-  int targetDistance = 20;
-  int runPwm = 30;
+  int targetDistance = 25;
+  int runPwm = 40;
   int angle = 74;
   int turnPwm = 100;
 


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
左折後に右エッジ、右折後に左エッジに切り替えるよう変更した。(変更前は逆)

変更前）右左折によって黒線を超え、その後PIDで黒線を捕捉する
変更後）右左折は黒線の手前で止まり、PIDで黒線を捕捉する

回転距離が短くなるため、動作時間の短縮が見込める。

# 動作テスト

## 実験方法
右左折直後に交点間移動を行い、時間と成功率を計測する。
右左折後、ライントレースできずにコースアウトした場合や、右左折中にブロックを放した場合を失敗とする。

足りない回転量を交点間移動に依存しているため、交点間移動も含めて測定している。

## 実験データ

|   |  修正前  |  修正後  |
| ---- | ---- | ---- |
|  動作時間  |  3.28734704  |  3.00676198  |
|  成功率  |  90%(45/50)  |  100%(50/50)  |

## 実験結果

https://user-images.githubusercontent.com/83441177/138490878-2ec5d0fa-9d50-4e6c-8393-89581b375e06.mp4


## 添付資料
