### PR TITLE
close  #213 ピボットターン設置の調整

### DIFF
--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -17,7 +17,7 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   int rotateFirstPwm = 10;     //最初に回頭するPwm
   int pivotAngle = 50;         //ピボットターンの角度
   int pivotPwm = 40;           //ピボットターンのPwm値50
-  int rotateSecondAngle = 80;  //二回目の回頭の角度65 //80
+  int rotateSecondAngle = 85;  //二回目の回頭の角度65 //80
   int rotateSecondPwm = 15;    //二回目の回頭のPwm値10
   int forwardDistance = 90;    // 前進する距離100
   int backDistance = 80;       //後退する距離90
@@ -43,4 +43,5 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   }
+  controller.sleep(50);
 }

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -13,7 +13,7 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   int runDistance = 86;  //最初に直進する距離
   int runPwm = 10;       //最初に直進する際のPwm値
   int rotateAngle = 44;  //回頭の角度
-  int rotatePwm = 10;    //回頭のPwm値
+  int rotatePwm = 100;    //回頭のPwm値
   int backPwm = -15;     //位置調整用のPwm値
 
   LineTracer lineTracer(isClockwise);
@@ -22,86 +22,16 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
 
   //ピボットターンする
   if(isClockwise) {
-    straightRunner.runStraightToDistance(runDistance, runPwm);
-    rotation.rotateRight(rotateAngle, rotatePwm);
-    straightRunner.runStraightToDistance(20, 15);
-    rotation.rotateRight(rotateAngle, rotatePwm);
-    setBlockPivotThrow(isClockwise);
-    straightRunner.runStraightToDistance(10, backPwm);
+    straightRunner.runStraightToDistance(16, runPwm);
+    rotation.turnForwardRightPivot(50, 30);
+    rotation.rotateRight(75, 100);
+    straightRunner.runStraightToDistance(150, 50);
+    straightRunner.runStraightToDistance(145, -50);
   } else {
-    straightRunner.runStraightToDistance(86, runPwm);
-    rotation.rotateLeft(rotateAngle, rotatePwm);
-    straightRunner.runStraightToDistance(22, 15);
-    rotation.rotateLeft(rotateAngle, rotatePwm);
-    setBlockPivotThrow(isClockwise);
-    straightRunner.runStraightToDistance(10, backPwm);
+    straightRunner.runStraightToDistance(16, runPwm);
+    rotation.turnForwardLeftPivot(45, rotatePwm);
+    rotation.rotateLeft(80, rotatePwm);
+    straightRunner.runStraightToDistance(150, 50);
+    straightRunner.runStraightToDistance(145, -50);
   }
-}
-
-void BlockPivotTurn::setBlockPivotThrow(bool isClockwise)
-{
-  double runDistance = 100;
-  int runPwm = 30;
-  int angle = 45;
-  int rotatePwm = 100;
-  int leftSign = isClockwise ? 1 : -1;
-  int rightSign = isClockwise ? -1 : 1;
-  double diffLeftDistance;
-  double diffRightDistance;
-  int leftPwm;
-  int rightPwm;
-  double targetDistance = M_PI * TREAD * angle / 360;
-  double targetLeftDistance;
-  double targetRightDistance;
-  int armPwm = 70;
-
-  // アームを水平にする処理を無効化
-  ArmMotion::setKeepFlag(false);
-  //回頭する
-  targetLeftDistance
-      = Mileage::calculateWheelMileage(measurer.getLeftCount()) + targetDistance * leftSign;
-  targetRightDistance
-      = Mileage::calculateWheelMileage(measurer.getRightCount()) + targetDistance * rightSign;
-
-  //両輪が目標距離に到達するまでループ
-  while(leftSign != 0 || rightSign != 0) {
-    // 残りの移動距離
-    diffLeftDistance
-        = (targetLeftDistance - Mileage::calculateWheelMileage(measurer.getLeftCount())) * leftSign;
-    diffRightDistance
-        = (targetRightDistance - Mileage::calculateWheelMileage(measurer.getRightCount()))
-          * rightSign;
-
-    // 目標距離に到達した場合
-    if(diffLeftDistance <= 0) {
-      leftSign = 0;
-    }
-    if(diffRightDistance <= 0) {
-      rightSign = 0;
-    }
-
-    // PWM値 = 残りの走行距離/走行距離 * 指定PWM値(最小値 MIN_PWM)
-    leftPwm = (diffLeftDistance / targetDistance * rotatePwm >= MIN_PWM)
-                  ? diffLeftDistance / targetDistance * rotatePwm
-                  : MIN_PWM;
-    rightPwm = (diffRightDistance / targetDistance * rotatePwm >= MIN_PWM)
-                   ? diffRightDistance / targetDistance * rotatePwm
-                   : MIN_PWM;
-    controller.setLeftMotorPwm(abs(leftPwm) * leftSign);
-    controller.setRightMotorPwm(abs(rightPwm) * rightSign);
-
-    //アームの動作
-    if(measurer.getArmMotorCount() >= 40) {
-      armPwm = 0;
-    }
-    controller.setArmMotorPwm(armPwm);
-
-    // 10ミリ秒待機
-    controller.sleep();
-  }
-  // アームを水平にする処理を有効化
-  ArmMotion::setKeepFlag(true);
-
-  //モータの停止
-  controller.stopMotor();
 }

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -28,7 +28,7 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   if(isClockwise) {
     straightRunner.runStraightToDistance(runDistance, runFirstPwm);
     rotation.turnForwardRightPivot(pivotAngle, pivotPwm);
-    rotation.rotateRight(rotateAngle, rotatePwm);
+    rotation.rotateRight(rotateAngle - 3, rotatePwm);
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   } else {

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -10,11 +10,15 @@ BlockPivotTurn::BlockPivotTurn() : BingoMotion(100, 100) {}
 
 void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
 {
-  int runDistance = 86;  //最初に直進する距離
-  int runPwm = 10;       //最初に直進する際のPwm値
-  int rotateAngle = 44;  //回頭の角度
-  int rotatePwm = 100;    //回頭のPwm値
-  int backPwm = -15;     //位置調整用のPwm値
+  int runDistance = 16;       //最初に直進する距離
+  int runFirstPwm = 10;       //最初に直進する際のPwm値
+  int pivotAngle = 45;        //ピボットターンの角度
+  int pivotPwm = 40;          //ピボットターンのPwm値
+  int rotateAngle = 85;       //回頭の角度
+  int rotatePwm = 20;         //回頭のPwm値
+  int forwardDistance = 100;  // 前進する距離
+  int backDistance = 90;      //後退する距離
+  int runPwm = 50;            //前進、後退する際のPwm値
 
   LineTracer lineTracer(isClockwise);
   InCrossLeft inCrossLeft(lineTracer);
@@ -22,16 +26,16 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
 
   //ピボットターンする
   if(isClockwise) {
-    straightRunner.runStraightToDistance(16, runPwm);
-    rotation.turnForwardRightPivot(50, 30);
-    rotation.rotateRight(75, 100);
-    straightRunner.runStraightToDistance(150, 50);
-    straightRunner.runStraightToDistance(145, -50);
+    straightRunner.runStraightToDistance(runDistance, runFirstPwm);
+    rotation.turnForwardRightPivot(pivotAngle, pivotPwm);
+    rotation.rotateRight(rotateAngle, rotatePwm);
+    straightRunner.runStraightToDistance(forwardDistance, runPwm);
+    straightRunner.runStraightToDistance(backDistance, -runPwm);
   } else {
-    straightRunner.runStraightToDistance(16, runPwm);
-    rotation.turnForwardLeftPivot(45, rotatePwm);
-    rotation.rotateLeft(80, rotatePwm);
-    straightRunner.runStraightToDistance(150, 50);
-    straightRunner.runStraightToDistance(145, -50);
+    straightRunner.runStraightToDistance(runDistance, runPwm);
+    rotation.turnForwardLeftPivot(pivotAngle, pivotAngle);  // pwm:20
+    rotation.rotateLeft(rotateAngle, rotatePwm);            // pwm:40
+    straightRunner.runStraightToDistance(forwardDistance, runPwm);
+    straightRunner.runStraightToDistance(backDistance, -runPwm);
   }
 }

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -5,31 +5,37 @@
  */
 
 #include "BlockPivotTurn.h"
+#include "Clock.h"
 
 BlockPivotTurn::BlockPivotTurn() : BingoMotion(2.0, 1.41) {}
 
 void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
 {
-  int runDistance = 40;       //最初に直進する距離
-  int runFirstPwm = 10;       //最初に直進する際のPwm値
-  int pivotAngle = 45;        //ピボットターンの角度
-  int pivotPwm = 40;          //ピボットターンのPwm値
-  int rotateAngle;            //回頭の角度
-  int rotatePwm = 20;         //回頭のPwm値
-  int forwardDistance = 100;  // 前進する距離
-  int backDistance = 90;      //後退する距離
-  int runPwm = 30;            //前進、後退する際のPwm値
+  int runDistance = 40;      //最初に直進する距離
+  int runFirstPwm = 10;      //最初に直進する際のPwm値
+  int pivotAngle = 45;       //ピボットターンの角度
+  int pivotPwm = 50;         //ピボットターンのPwm値50
+  int rotateAngle = 90;      //回頭の角度
+  int rotatePwm = 10;        //回頭のPwm値10
+  int forwardDistance = 90;  // 前進する距離100
+  int backDistance = 80;     //後退する距離90
+  int runPwm = 30;           //前進、後退する際のPwm値
+  int start, end;
 
+  ev3api::Clock clock;
   LineTracer lineTracer(isClockwise);
   InCrossLeft inCrossLeft(lineTracer);
   InCrossRight inCrossRight(lineTracer);
 
-  if(lineTracer.getIsLeftEdge() == true) {
-    rotateAngle = 80;
-  } else {
-    rotateAngle = 89;
-  }
   //ピボットターンする
+  start = clock.now();
+
+  if(lineTracer.getIsLeftEdge() == true) {
+    printf("右\n");
+  } else {
+    printf("左");
+  }
+
   if(isClockwise) {
     straightRunner.runStraightToDistance(runDistance, runFirstPwm);
     rotation.turnForwardRightPivot(pivotAngle, pivotPwm);
@@ -38,9 +44,11 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   } else {
     straightRunner.runStraightToDistance(runDistance, runPwm);
-    rotation.turnForwardLeftPivot(pivotAngle, pivotAngle);  // pwm:20
-    rotation.rotateLeft(rotateAngle, rotatePwm);            // pwm:40
+    rotation.turnForwardLeftPivot(pivotAngle, pivotAngle);
+    rotation.rotateLeft(rotateAngle, rotatePwm);
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   }
+  end = clock.now();
+  printf("%lf秒\n", float((end - start) / 1000000.0));
 }

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -28,14 +28,6 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   InCrossRight inCrossRight(lineTracer);
 
   //ピボットターンする
-  start = clock.now();
-
-  if(lineTracer.getIsLeftEdge() == true) {
-    printf("右\n");
-  } else {
-    printf("左");
-  }
-
   if(isClockwise) {
     straightRunner.runStraightToDistance(runDistance, runFirstPwm);
     rotation.turnForwardRightPivot(pivotAngle, pivotPwm);
@@ -49,6 +41,4 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   }
-  end = clock.now();
-  printf("%lf秒\n", float((end - start) / 1000000.0));
 }

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -10,7 +10,7 @@ BlockPivotTurn::BlockPivotTurn() : BingoMotion(2.0, 1.41) {}
 
 void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
 {
-  int runDistance = 16;       //最初に直進する距離
+  int runDistance = 40;       //最初に直進する距離
   int runFirstPwm = 10;       //最初に直進する際のPwm値
   int pivotAngle = 45;        //ピボットターンの角度
   int pivotPwm = 40;          //ピボットターンのPwm値

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -11,16 +11,18 @@ BlockPivotTurn::BlockPivotTurn() : BingoMotion(2.0, 1.41) {}
 
 void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
 {
-  int runDistance = 40;      //最初に直進する距離
-  int runFirstPwm = 10;      //最初に直進する際のPwm値
-  int pivotAngle = 45;       //ピボットターンの角度
-  int pivotPwm = 50;         //ピボットターンのPwm値50
-  int rotateAngle = 90;      //回頭の角度
-  int rotatePwm = 10;        //回頭のPwm値10
-  int forwardDistance = 90;  // 前進する距離100
-  int backDistance = 80;     //後退する距離90
-  int runPwm = 30;           //前進、後退する際のPwm値
-
+  int runDistance = 40;        //最初に直進する距離
+  int runFirstPwm = 10;        //最初に直進する際のPwm値
+  int rotateFirstAngle = 10;   //最初に回頭する角度
+  int rotateFirstPwm = 10;     //最初に回頭するPwm
+  int pivotAngle = 50;         //ピボットターンの角度
+  int pivotPwm = 40;           //ピボットターンのPwm値50
+  int rotateSecondAngle = 80;  //二回目の回頭の角度65 //80
+  int rotateSecondPwm = 15;    //二回目の回頭のPwm値10
+  int forwardDistance = 90;    // 前進する距離100
+  int backDistance = 80;       //後退する距離90
+  int runPwm = 30;             //前進、後退する際のPwm値
+  int strat, end;
   LineTracer lineTracer(isClockwise);
   InCrossLeft inCrossLeft(lineTracer);
   InCrossRight inCrossRight(lineTracer);
@@ -28,14 +30,16 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   //ピボットターンする
   if(isClockwise) {
     straightRunner.runStraightToDistance(runDistance, runFirstPwm);
+    rotation.rotateRight(rotateFirstAngle, rotateFirstPwm);
     rotation.turnForwardRightPivot(pivotAngle, pivotPwm);
-    rotation.rotateRight(rotateAngle, rotatePwm);
+    rotation.rotateRight(rotateSecondAngle, rotateSecondPwm);
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   } else {
     straightRunner.runStraightToDistance(runDistance, runPwm);
+    rotation.rotateRight(rotateFirstAngle, rotateFirstPwm);
     rotation.turnForwardLeftPivot(pivotAngle, pivotAngle);
-    rotation.rotateLeft(rotateAngle, rotatePwm);
+    rotation.rotateLeft(rotateSecondAngle, rotateSecondPwm);
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   }

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -20,9 +20,7 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   int forwardDistance = 90;  // 前進する距離100
   int backDistance = 80;     //後退する距離90
   int runPwm = 30;           //前進、後退する際のPwm値
-  int start, end;
 
-  ev3api::Clock clock;
   LineTracer lineTracer(isClockwise);
   InCrossLeft inCrossLeft(lineTracer);
   InCrossRight inCrossRight(lineTracer);

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -20,9 +20,9 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   int rotateSecondAngle = 85;  //二回目の回頭の角度65 //80
   int rotateSecondPwm = 15;    //二回目の回頭のPwm値10
   int forwardDistance = 90;    // 前進する距離100
-  int backDistance = 80;       //後退する距離90
+  int backDistance = 90;       //後退する距離90
   int runPwm = 30;             //前進、後退する際のPwm値
-  int strat, end;
+
   LineTracer lineTracer(isClockwise);
   InCrossLeft inCrossLeft(lineTracer);
   InCrossRight inCrossRight(lineTracer);
@@ -34,14 +34,14 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
     rotation.turnForwardRightPivot(pivotAngle, pivotPwm);
     rotation.rotateRight(rotateSecondAngle, rotateSecondPwm);
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
-    straightRunner.runStraightToDistance(backDistance, -runPwm);
+    straightRunner.runStraightToDistance(backDistance, -(runPwm - 10));
   } else {
     straightRunner.runStraightToDistance(runDistance, runPwm);
     rotation.rotateRight(rotateFirstAngle, rotateFirstPwm);
     rotation.turnForwardLeftPivot(pivotAngle, pivotAngle);
     rotation.rotateLeft(rotateSecondAngle, rotateSecondPwm);
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
-    straightRunner.runStraightToDistance(backDistance, -runPwm);
+    straightRunner.runStraightToDistance(backDistance, -(runPwm - 10));
   }
-  controller.sleep(50);
+  controller.sleep(500);
 }

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -14,7 +14,7 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   int runFirstPwm = 10;       //最初に直進する際のPwm値
   int pivotAngle = 45;        //ピボットターンの角度
   int pivotPwm = 40;          //ピボットターンのPwm値
-  int rotateAngle = 85;       //回頭の角度
+  int rotateAngle;            //回頭の角度
   int rotatePwm = 20;         //回頭のPwm値
   int forwardDistance = 100;  // 前進する距離
   int backDistance = 90;      //後退する距離
@@ -24,17 +24,22 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   InCrossLeft inCrossLeft(lineTracer);
   InCrossRight inCrossRight(lineTracer);
 
+  if(lineTracer.getIsLeftEdge() == true) {
+    rotateAngle = 80;
+  } else {
+    rotateAngle = 89;
+  }
   //ピボットターンする
   if(isClockwise) {
     straightRunner.runStraightToDistance(runDistance, runFirstPwm);
     rotation.turnForwardRightPivot(pivotAngle, pivotPwm);
-    rotation.rotateRight(rotateAngle - 5, rotatePwm);
+    rotation.rotateRight(rotateAngle, rotatePwm);
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   } else {
     straightRunner.runStraightToDistance(runDistance, runPwm);
     rotation.turnForwardLeftPivot(pivotAngle, pivotAngle);  // pwm:20
-    rotation.rotateLeft(rotateAngle - 5, rotatePwm);        // pwm:40
+    rotation.rotateLeft(rotateAngle, rotatePwm);            // pwm:40
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   }

--- a/module/BingoMotion/BlockPivotTurn.cpp
+++ b/module/BingoMotion/BlockPivotTurn.cpp
@@ -18,7 +18,7 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   int rotatePwm = 20;         //回頭のPwm値
   int forwardDistance = 100;  // 前進する距離
   int backDistance = 90;      //後退する距離
-  int runPwm = 50;            //前進、後退する際のPwm値
+  int runPwm = 30;            //前進、後退する際のPwm値
 
   LineTracer lineTracer(isClockwise);
   InCrossLeft inCrossLeft(lineTracer);
@@ -28,13 +28,13 @@ void BlockPivotTurn::setBlockPivotTurn(bool isClockwise)
   if(isClockwise) {
     straightRunner.runStraightToDistance(runDistance, runFirstPwm);
     rotation.turnForwardRightPivot(pivotAngle, pivotPwm);
-    rotation.rotateRight(rotateAngle - 3, rotatePwm);
+    rotation.rotateRight(rotateAngle - 5, rotatePwm);
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   } else {
     straightRunner.runStraightToDistance(runDistance, runPwm);
     rotation.turnForwardLeftPivot(pivotAngle, pivotAngle);  // pwm:20
-    rotation.rotateLeft(rotateAngle, rotatePwm);            // pwm:40
+    rotation.rotateLeft(rotateAngle - 5, rotatePwm);        // pwm:40
     straightRunner.runStraightToDistance(forwardDistance, runPwm);
     straightRunner.runStraightToDistance(backDistance, -runPwm);
   }

--- a/module/BingoMotion/BlockPivotTurn.h
+++ b/module/BingoMotion/BlockPivotTurn.h
@@ -35,12 +35,6 @@ class BlockPivotTurn : public BingoMotion {
   Measurer measurer;
   Controller controller;
 
-  /**
-   * @brief ピボットターン設置用の投げ入れ設置
-   * @param isClockwise 投げ入れる向き true: 右回転
-   */
-  void setBlockPivotThrow(bool isClockwise);
-
   const double TREAD = 140;  // 走行体のトレッド幅（両輪の間の距離）[mm]
   const int MIN_PWM = 10;    // モーターパワーの最小値
 };


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
動作の変更

直進→45度ピボットターン→85度回頭→サークルの中心まで移動→元の位置まで戻る

CI上で起きていたブロック設置動作後にはねる動きを修正した。

設置動作後の方向転換が正常に動くように最初に直進する距離のパラメータの調整を行った。

# 動作テスト

## 実験方法
手元環境で左右ピボットターン設置を各10回ずつの計測を行う

CI上での動作を確認
## 実験データ


左ピボットターン

|時間(s)| 角度の差(deg)|
| ------------- | ------------- |
|5.654713|3.2|
|5.614579|5.1|
|5.684998|1.0|
|5.654998|3.6|
|5.640020|1.0|
|5.635011|3.1|
|5.630023|4.1|
|5.750015|1.4|
|5.630018|3.8|
|5.650012|4.7|

右ピボットターン
|時間(s)| 角度の差(deg)|
| ------------- | ------------- |
|6.040572|2.5|
|6.070039|4.9|
|6.120022|2.0|
|6.130004|0.1|
|6.070027|0.5|
|6.100025|0.4|
|6.040037|0.9|
|6.060025|0.6|
|5.974998|4.7|
|6.120018|0.3|

修正前と修正後の比較

左ピボットターン設置
| 修正前時間(s) |修正後時間(s) |修正前の角度の差(deg)| 修正後の角度の差(deg)|
| ------------- | ------------- | ------------- | ------------- |
|       5.7144688          |       5.6544387           |          2.47             |           2.9          |

右ピボットターン設置
|修正前時間(s)|修正後時間(s) |修正前の角度の差(deg)| 修正後の角度の差(deg)|
| ------------- | ------------- | ------------- | ------------- |
|       5.6919968          |          6.0725767       |             1.74          |      1.69               |


CI上での動作確認(各24回)
|左ピボットターン設置| 右ピボットターン設置|
| ------------- | ------------- |
|100%| 83%|

## 実験結果

## 添付資料

https://user-images.githubusercontent.com/83230897/138260104-712f34aa-718a-4be6-8c62-14a25d8da72b.mp4


https://user-images.githubusercontent.com/83230897/138260574-6df08a91-958a-47db-a567-da313ae6b0a8.mp4





