### PR TITLE
close #234 黒ブロック運搬後の停止時間を減らす

### DIFF
--- a/module/RoutePlanner/MoveCostCalculator.cpp
+++ b/module/RoutePlanner/MoveCostCalculator.cpp
@@ -6,13 +6,17 @@
 
 #include "MoveCostCalculator.h"
 
+MoveCostCalculator::MoveCostCalculator(MotionPerformer& _motionPerformer)
+  : motionPerformer(_motionPerformer)
+{
+}
+
 double MoveCostCalculator::calculateMoveCost(std::pair<Coordinate, Direction> current,
                                              std::pair<Coordinate, Direction> next,
                                              bool isLeftCourse)
 {
   MOTION nextMotion = MotionConverter::decideMotion(current, next);
-  LineTracer lineTracer(isLeftCourse);
-  MotionPerformer motionPerformer(lineTracer);
+
   // 時間コストと誤差コストの比
   double timeRatio = 0.7;
   double riskRatio = 1.0 - timeRatio;

--- a/module/RoutePlanner/MoveCostCalculator.h
+++ b/module/RoutePlanner/MoveCostCalculator.h
@@ -11,6 +11,9 @@
 
 class MoveCostCalculator {
  public:
+  //コンストラクタ
+  MoveCostCalculator(MotionPerformer& _motionPerformer);
+
   /**
    * @fn static int calculateMoveCost(std::pair<Coordinate, Direction> current,std::pair<Coordinate,
    * Direction> next,bool isLeftCourse);
@@ -19,8 +22,11 @@ class MoveCostCalculator {
    * @param next 移動後の座標と向き
    * @return 移動コスト
    */
-  static double calculateMoveCost(std::pair<Coordinate, Direction> current,
-                                  std::pair<Coordinate, Direction> next, bool isLeftCourse);
+  double calculateMoveCost(std::pair<Coordinate, Direction> current,
+                           std::pair<Coordinate, Direction> next, bool isLeftCourse);
+
+ private:
+  MotionPerformer& motionPerformer;
 };
 
 #endif

--- a/module/RoutePlanner/RouteCalculator.cpp
+++ b/module/RoutePlanner/RouteCalculator.cpp
@@ -14,6 +14,10 @@ RouteCalculator::RouteCalculator(CourseInfo& courseInfo, Robot& robot, const boo
 std::vector<std::pair<Coordinate, Direction>> RouteCalculator::calculateRoute(
     Coordinate start, Coordinate goal, Coordinate destination)
 {
+  LineTracer lineTracer(isLeftCourse);
+  MotionPerformer motionPerformer(lineTracer);
+  MoveCostCalculator moveCostCalculator(motionPerformer);
+
   std::vector<AstarInfo> open;   //これから探索するノードを格納
   std::vector<AstarInfo> close;  //探索済みのノードを格納
   std::vector<std::pair<Coordinate, Direction>> routeCoordinate;  //最短経路の座標を格納
@@ -95,7 +99,7 @@ std::vector<std::pair<Coordinate, Direction>> RouteCalculator::calculateRoute(
 
           //実コスト＝そのノードまでの距離＋向きコスト＋移動コスト＋推定コスト（マンハッタン距離）
           actualCost = route[elem.coordinate.x][elem.coordinate.y].cost + directionCost
-                       + MoveCostCalculator::calculateMoveCost(
+                       + moveCostCalculator.calculateMoveCost(
                            std::make_pair(elem.coordinate, preDirection),
                            std::make_pair(m.coordinate, currentDirection), isLeftCourse)
                        + calculateManhattan(m.coordinate);
@@ -110,7 +114,7 @@ std::vector<std::pair<Coordinate, Direction>> RouteCalculator::calculateRoute(
           //ゴール以外は向きコストを考慮せず探索する
           //実コスト＝そのノードまでの距離＋移動コスト＋推定コスト（マンハッタン距離）
           actualCost = route[elem.coordinate.x][elem.coordinate.y].cost
-                       + MoveCostCalculator::calculateMoveCost(
+                       + moveCostCalculator.calculateMoveCost(
                            std::make_pair(elem.coordinate, preDirection),
                            std::make_pair(m.coordinate, currentDirection), isLeftCourse)
                        + calculateManhattan(m.coordinate);


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- 動作コスト算出関数を呼び出すたびにインスタンスを生成せず、RouteCalculatorの経路計算関数内で1度のみインスタンスを生成し、それを利用するように変更(変更前がなぜあのような停止を発生させるかはよくわからない)

# 動作テスト
- CIの動画にて、黒ブロック運搬後の停止時間が減少しているかを確認する
***動画にて停止時間が減少(ほぼ停止していない)していることを確認***

## 添付資料
