### PR TITLE
close #235 右左折の精度調整

### DIFF
--- a/module/BingoMotion/InCrossLeft.cpp
+++ b/module/BingoMotion/InCrossLeft.cpp
@@ -13,7 +13,7 @@ InCrossLeft::InCrossLeft(LineTracer& _lineTracer) : BingoMotion(1.23, 1.09), lin
 void InCrossLeft::runLeft(void)
 {
   int targetDistance = 25;
-  int runPwm = 40;
+  int runPwm = 30;
   int angle = 74;
   int turnPwm = 100;
 

--- a/module/BingoMotion/InCrossLeft.cpp
+++ b/module/BingoMotion/InCrossLeft.cpp
@@ -15,7 +15,7 @@ void InCrossLeft::runLeft(void)
   int targetDistance = 25;
   int runPwm = 30;
   int angle = 74;
-  int turnPwm = 100;
+  int turnPwm = 90;
 
   //ピボットターン後の位置を調整するため、直進する
   straightRunner.runStraightToDistance(targetDistance, runPwm);

--- a/module/BingoMotion/InCrossRight.cpp
+++ b/module/BingoMotion/InCrossRight.cpp
@@ -16,7 +16,7 @@ void InCrossRight::runRight(void)
   int targetDistance = 25;
   int runPwm = 30;
   int angle = 74;
-  int turnPwm = 100;
+  int turnPwm = 90;
 
   //ピボットターン後の位置を調整するため、直進する
   straightRunner.runStraightToDistance(targetDistance, runPwm);

--- a/module/BingoMotion/InCrossRight.cpp
+++ b/module/BingoMotion/InCrossRight.cpp
@@ -14,7 +14,7 @@ InCrossRight::InCrossRight(LineTracer& _lineTracer)
 void InCrossRight::runRight(void)
 {
   int targetDistance = 25;
-  int runPwm = 40;
+  int runPwm = 30;
   int angle = 74;
   int turnPwm = 100;
 

--- a/module/RoutePlanner/MoveCostCalculator.cpp
+++ b/module/RoutePlanner/MoveCostCalculator.cpp
@@ -6,13 +6,17 @@
 
 #include "MoveCostCalculator.h"
 
+MoveCostCalculator::MoveCostCalculator(MotionPerformer& _motionPerformer)
+  : motionPerformer(_motionPerformer)
+{
+}
+
 double MoveCostCalculator::calculateMoveCost(std::pair<Coordinate, Direction> current,
                                              std::pair<Coordinate, Direction> next,
                                              bool isLeftCourse)
 {
   MOTION nextMotion = MotionConverter::decideMotion(current, next);
-  LineTracer lineTracer(isLeftCourse);
-  MotionPerformer motionPerformer(lineTracer);
+
   // 時間コストと誤差コストの比
   double timeRatio = 0.7;
   double riskRatio = 1.0 - timeRatio;

--- a/module/RoutePlanner/MoveCostCalculator.h
+++ b/module/RoutePlanner/MoveCostCalculator.h
@@ -11,6 +11,9 @@
 
 class MoveCostCalculator {
  public:
+  //コンストラクタ
+  MoveCostCalculator(MotionPerformer& _motionPerformer);
+
   /**
    * @fn static int calculateMoveCost(std::pair<Coordinate, Direction> current,std::pair<Coordinate,
    * Direction> next,bool isLeftCourse);
@@ -19,8 +22,11 @@ class MoveCostCalculator {
    * @param next 移動後の座標と向き
    * @return 移動コスト
    */
-  static double calculateMoveCost(std::pair<Coordinate, Direction> current,
-                                  std::pair<Coordinate, Direction> next, bool isLeftCourse);
+  double calculateMoveCost(std::pair<Coordinate, Direction> current,
+                           std::pair<Coordinate, Direction> next, bool isLeftCourse);
+
+ private:
+  MotionPerformer& motionPerformer;
 };
 
 #endif

--- a/module/RoutePlanner/RouteCalculator.cpp
+++ b/module/RoutePlanner/RouteCalculator.cpp
@@ -14,6 +14,10 @@ RouteCalculator::RouteCalculator(CourseInfo& courseInfo, Robot& robot, const boo
 std::vector<std::pair<Coordinate, Direction>> RouteCalculator::calculateRoute(
     Coordinate start, Coordinate goal, Coordinate destination)
 {
+  LineTracer lineTracer(isLeftCourse);
+  MotionPerformer motionPerformer(lineTracer);
+  MoveCostCalculator moveCostCalculator(motionPerformer);
+
   std::vector<AstarInfo> open;   //これから探索するノードを格納
   std::vector<AstarInfo> close;  //探索済みのノードを格納
   std::vector<std::pair<Coordinate, Direction>> routeCoordinate;  //最短経路の座標を格納
@@ -95,7 +99,7 @@ std::vector<std::pair<Coordinate, Direction>> RouteCalculator::calculateRoute(
 
           //実コスト＝そのノードまでの距離＋向きコスト＋移動コスト＋推定コスト（マンハッタン距離）
           actualCost = route[elem.coordinate.x][elem.coordinate.y].cost + directionCost
-                       + MoveCostCalculator::calculateMoveCost(
+                       + moveCostCalculator.calculateMoveCost(
                            std::make_pair(elem.coordinate, preDirection),
                            std::make_pair(m.coordinate, currentDirection), isLeftCourse)
                        + calculateManhattan(m.coordinate);
@@ -110,7 +114,7 @@ std::vector<std::pair<Coordinate, Direction>> RouteCalculator::calculateRoute(
           //ゴール以外は向きコストを考慮せず探索する
           //実コスト＝そのノードまでの距離＋移動コスト＋推定コスト（マンハッタン距離）
           actualCost = route[elem.coordinate.x][elem.coordinate.y].cost
-                       + MoveCostCalculator::calculateMoveCost(
+                       + moveCostCalculator.calculateMoveCost(
                            std::make_pair(elem.coordinate, preDirection),
                            std::make_pair(m.coordinate, currentDirection), isLeftCourse)
                        + calculateManhattan(m.coordinate);


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
試走会で、右左折動作中にブロックを放してしまったシーンがあったため、PWM値を下げた。
CI、手元環境での再現率は低い。