### PR TITLE
close #239 ブロックを運搬できないパターンを攻略するアルゴリズムの実装

### DIFF
--- a/module/RoutePlanner/BlockSelector.cpp
+++ b/module/RoutePlanner/BlockSelector.cpp
@@ -67,9 +67,9 @@ BLOCK_ID BlockSelector::selectBlock()
     Coordinate targetCircleCoord
         = courseInfo.getBlockCircle(static_cast<CIRCLE_ID>(targetCircleNumber)).getCoordinate();
     //もう１つの運搬先サークルのサークル番号、座標
-    int targetCircleNumber_alt = static_cast<int>(destinationList.getDestination_alt(blockId));
-    Coordinate targetCircleCoord_alt
-        = courseInfo.getBlockCircle(static_cast<CIRCLE_ID>(targetCircleNumber_alt)).getCoordinate();
+    int targetCircleNumberAlt = static_cast<int>(destinationList.getDestinationAlt(blockId));
+    Coordinate targetCircleCoordAlt
+        = courseInfo.getBlockCircle(static_cast<CIRCLE_ID>(targetCircleNumberAlt)).getCoordinate();
 
     // 運搬済みだった場合
     if(isCarriedBlock(blockId)) continue;
@@ -88,9 +88,9 @@ BLOCK_ID BlockSelector::selectBlock()
     // ブロックの運搬先に到着できない場合
     if(route.front().first != targetBlockCoord || route.back().first != targetCircleCoord) {
       //もう1つの運搬先への経路を算出する
-      route = routeCalculator.calculateRoute(targetBlockCoord, targetCircleCoord_alt,
-                                             targetCircleCoord_alt);
-      if(route.front().first == targetBlockCoord && route.back().first == targetCircleCoord_alt) {
+      route = routeCalculator.calculateRoute(targetBlockCoord, targetCircleCoordAlt,
+                                             targetCircleCoordAlt);
+      if(route.front().first == targetBlockCoord && route.back().first == targetCircleCoordAlt) {
         //もしもう1つの運搬先に運搬可能であれば、運搬先を変更する事で運搬可能とするが、運搬先を変更せずに運搬できるブロックを優先する
         //(すなわち、運搬先を変更することでどれだけ距離が短くなろうと優先はしない)
         needsSwap[static_cast<int>(blockId)] = true;
@@ -168,7 +168,6 @@ BLOCK_ID BlockSelector::selectBlock()
     }
     // ここまでの項目が等しい場合は、既存(idが若い)のブロックを採用する
   }
-  // printf("%d %d\n", bestBlockId, destinationList.getDestination(BLOCK_ID::ID4));
   //運搬できるブロックがなかった場合は運搬先を入れ替える(一番ブロックIDが大きいブロックが選ばれる)
   if(bestBlockId == BLOCK_ID::NONE) {
     for(int i = 0; i < 8; i++) {
@@ -178,7 +177,6 @@ BLOCK_ID BlockSelector::selectBlock()
     }
     destinationList.swapDestination(bestBlockId);
   }
-  // printf("%d %d\n", bestBlockId, destinationList.getDestination(bestBlockId));
   // ブロックが運搬されたとして、運搬可能範囲を開放
   for(int i = B_ZERO; i < B_SIZE; i++) {
     int bestBlockNumber = static_cast<int>(bestBlockId);

--- a/module/RoutePlanner/BlockSelector.h
+++ b/module/RoutePlanner/BlockSelector.h
@@ -32,7 +32,7 @@ class BlockSelector {
 
  private:
   CourseInfo courseInfo;
-  DestinationList destinationList;
+  DestinationList& destinationList;
   Robot robot;
   const bool isLeftCourse;
 

--- a/module/RoutePlanner/DestinationList.cpp
+++ b/module/RoutePlanner/DestinationList.cpp
@@ -63,11 +63,15 @@ DestinationList::DestinationList(CourseInfo& courseInfo)
     int secondBlockNumber = static_cast<int>(secondBlockId);
     // 運搬距離の合計を比較し、短い方を採用する
     if(pattern1 < pattern2) {
-      destinations[firstBlockNumber] = CIRCLE_IDS[color][0];
-      destinations[secondBlockNumber] = CIRCLE_IDS[color][1];
+      destinations[firstBlockNumber][0] = CIRCLE_IDS[color][0];
+      destinations[secondBlockNumber][0] = CIRCLE_IDS[color][1];
+      destinations[firstBlockNumber][1] = CIRCLE_IDS[color][1];
+      destinations[secondBlockNumber][1] = CIRCLE_IDS[color][0];
     } else {
-      destinations[firstBlockNumber] = CIRCLE_IDS[color][1];
-      destinations[secondBlockNumber] = CIRCLE_IDS[color][0];
+      destinations[firstBlockNumber][0] = CIRCLE_IDS[color][1];
+      destinations[secondBlockNumber][0] = CIRCLE_IDS[color][0];
+      destinations[firstBlockNumber][1] = CIRCLE_IDS[color][0];
+      destinations[secondBlockNumber][1] = CIRCLE_IDS[color][1];
     }
   }
 }
@@ -75,7 +79,11 @@ DestinationList::DestinationList(CourseInfo& courseInfo)
 // 指定されたブロックの運搬先サークルIDを返す
 CIRCLE_ID DestinationList::getDestination(BLOCK_ID blockId)
 {
-  return destinations[static_cast<int>(blockId)];
+  return destinations[static_cast<int>(blockId)][0];
+}
+CIRCLE_ID DestinationList::getDestination_alt(BLOCK_ID blockId)
+{
+  return destinations[static_cast<int>(blockId)][1];
 }
 
 // 座標間のマンハッタン距離を計算する
@@ -84,4 +92,18 @@ int DestinationList::calculateDistance(Coordinate& blockCoord, Coordinate& circl
   int dx = std::abs(blockCoord.x - circleCoord.x);
   int dy = std::abs(blockCoord.y - circleCoord.y);
   return dx + dy;
+}
+
+void DestinationList::change(int id)
+{
+  for(int i = 0; i < 8; i++) {
+    if(destinations[i][1] == destinations[static_cast<int>(id)][0]) {
+      CIRCLE_ID tmp = destinations[id][0];
+      CIRCLE_ID tmp1 = destinations[id][1];
+      destinations[id][0] = destinations[i][0];
+      destinations[id][1] = destinations[i][1];
+      destinations[i][0] = tmp;
+      destinations[i][1] = tmp1;
+    }
+  }
 }

--- a/module/RoutePlanner/DestinationList.cpp
+++ b/module/RoutePlanner/DestinationList.cpp
@@ -61,7 +61,7 @@ DestinationList::DestinationList(CourseInfo& courseInfo)
     // ブロックIDをint化
     int firstBlockNumber = static_cast<int>(firstBlockId);
     int secondBlockNumber = static_cast<int>(secondBlockId);
-    // 運搬距離の合計を比較し、短い方を採用する
+    // 運搬距離の合計を比較し、短い方を採用するが、詰みパターン対処のためにもう片方の運搬先も保持しておく
     if(pattern1 < pattern2) {
       destinations[firstBlockNumber][0] = CIRCLE_IDS[color][0];
       destinations[secondBlockNumber][0] = CIRCLE_IDS[color][1];
@@ -94,9 +94,10 @@ int DestinationList::calculateDistance(Coordinate& blockCoord, Coordinate& circl
   return dx + dy;
 }
 
-void DestinationList::change(int id)
+void DestinationList::swapDestination(BLOCK_ID blockId)
 {
-  for(int i = 0; i < 8; i++) {
+  int id = static_cast<int>(blockId);
+  for(int i = 0; i <= static_cast<int>(BLOCK_ID::ID7); i++) {
     if(destinations[i][1] == destinations[static_cast<int>(id)][0]) {
       CIRCLE_ID tmp = destinations[id][0];
       CIRCLE_ID tmp1 = destinations[id][1];

--- a/module/RoutePlanner/DestinationList.cpp
+++ b/module/RoutePlanner/DestinationList.cpp
@@ -81,7 +81,9 @@ CIRCLE_ID DestinationList::getDestination(BLOCK_ID blockId)
 {
   return destinations[static_cast<int>(blockId)][0];
 }
-CIRCLE_ID DestinationList::getDestination_alt(BLOCK_ID blockId)
+
+// 指定されたブロックのもう1つの運搬先サークルIDを返す
+CIRCLE_ID DestinationList::getDestinationAlt(BLOCK_ID blockId)
 {
   return destinations[static_cast<int>(blockId)][1];
 }

--- a/module/RoutePlanner/DestinationList.h
+++ b/module/RoutePlanner/DestinationList.h
@@ -24,7 +24,13 @@ class DestinationList {
    * @return 運搬先サークルID
    */
   CIRCLE_ID getDestination(BLOCK_ID blockId);
-  CIRCLE_ID getDestination_alt(BLOCK_ID blockId);
+
+  /**
+   * 指定されたブロックのもう１つの運搬先サークルIDを返す
+   * @param blockId ブロックID
+   * @return もう１つの運搬先サークルID
+   */
+  CIRCLE_ID getDestinationAlt(BLOCK_ID blockId);
 
   /**
    * ブロックの運搬先を、もう１つの同じ色のブロックの運搬先と入れ替える

--- a/module/RoutePlanner/DestinationList.h
+++ b/module/RoutePlanner/DestinationList.h
@@ -26,10 +26,14 @@ class DestinationList {
   CIRCLE_ID getDestination(BLOCK_ID blockId);
   CIRCLE_ID getDestination_alt(BLOCK_ID blockId);
 
-  void change(int id);
+  /**
+   * ブロックの運搬先を、もう１つの同じ色のブロックの運搬先と入れ替える
+   * @param blockId ブロックID
+   */
+  void swapDestination(BLOCK_ID blockId);
 
  private:
-  // 各ブロックの運搬先サークルID
+  // 各ブロックの運搬先サークルID(BLOCK0~7について、決定した運搬先ともう１つの運搬先の2つを保持)
   std::array<std::array<CIRCLE_ID, 2>, static_cast<int>(BLOCK_ID::ID7) + 1> destinations;
 
   /**

--- a/module/RoutePlanner/DestinationList.h
+++ b/module/RoutePlanner/DestinationList.h
@@ -24,10 +24,13 @@ class DestinationList {
    * @return 運搬先サークルID
    */
   CIRCLE_ID getDestination(BLOCK_ID blockId);
+  CIRCLE_ID getDestination_alt(BLOCK_ID blockId);
+
+  void change(int id);
 
  private:
   // 各ブロックの運搬先サークルID
-  std::array<CIRCLE_ID, static_cast<int>(BLOCK_ID::ID7) + 1> destinations;
+  std::array<std::array<CIRCLE_ID, 2>, static_cast<int>(BLOCK_ID::ID7) + 1> destinations;
 
   /**
    * 座標間のマンハッタン距離を計算する

--- a/module/RoutePlanner/RoutePlanner.cpp
+++ b/module/RoutePlanner/RoutePlanner.cpp
@@ -22,7 +22,7 @@ std::vector<std::vector<std::pair<Coordinate, Direction>>> RoutePlanner::planBin
   RouteCalculator routeCalculator(courseInfo, robot, isLeftCourse);
   int count = 0;
 
-  while(true) {
+  for(int i = 0; i < 8; i++) {
     // 運搬ブロックを決定する
     BLOCK_ID carryBlockId = blockSelector.selectBlock();
     // 運搬ブロックが存在しない場合、ループを抜ける

--- a/module/RoutePlanner/RoutePlanner.cpp
+++ b/module/RoutePlanner/RoutePlanner.cpp
@@ -22,7 +22,7 @@ std::vector<std::vector<std::pair<Coordinate, Direction>>> RoutePlanner::planBin
   RouteCalculator routeCalculator(courseInfo, robot, isLeftCourse);
   int count = 0;
 
-  for(int i = 0; i < 8; i++) {
+  while(true) {
     // 運搬ブロックを決定する
     BLOCK_ID carryBlockId = blockSelector.selectBlock();
     // 運搬ブロックが存在しない場合、ループを抜ける


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- BlockSelectorクラスのselectBlock関数に、運べるブロックがない場合に運搬先を変えることで運搬できるブロックを選択するような処理を追加
- Destinationクラスでもう１つの運搬先も保持するようにし、運搬先の入れ変え（本来の運搬先と選ばれなかった運搬先）を行う関数を追加


# 動作テスト
詰みパターンでも攻略ができるかを検証、BlockSelectorのテストコードにて入れ替えが必要ない場合は従来の処理のままであることを確認

変更前
https://etrobocon2021.moyashi.dev/01/results/2021-10-14/16-06-28/da55db21f7e546654457eae6ab63692a6776cba2-42.mp4

変更後

https://user-images.githubusercontent.com/66076307/139032034-311b833e-5164-43a8-9e16-15404f7c2cd9.mp4

## 添付資料
