### PR TITLE
close #250  第3ショートカットを使わない場合の検証

### DIFF
--- a/module/LineTraceArea.cpp
+++ b/module/LineTraceArea.cpp
@@ -78,8 +78,8 @@ void LineTraceArea::runLineTraceAreaShortcut()
   int curveDistance1 = 777;
   int straightDistance1 = 440;
   int curveDistance2 = 777;
-  int straightDistance2 = 1117;
-  int curveDistance3 = 700;
+  int straightDistance2 = 1250;
+  int curveDistance3 = 400;
   int straightDistance3 = 460;
 
   lineTracer.run(150, targetBrightness, 60, PidGain(0.3, 0.01, 0.01));
@@ -112,18 +112,7 @@ void LineTraceArea::runLineTraceAreaShortcut()
   }
 
   lineTracer.run(straightDistance2, targetBrightness, 100, PidGain(3, 1.2, 1));
-
-  //第三カーブ
-  initialDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
-  while(true) {
-    currentDistance = Mileage::calculateMileage(measurer.getRightCount(), measurer.getLeftCount());
-    if(currentDistance - initialDistance >= curveDistance3) {
-      break;
-    }
-    controller.setRightMotorPwm(63);
-    controller.setLeftMotorPwm(99);
-    controller.sleep();
-  }
+  lineTracer.run(curveDistance3, targetBrightness, 60, PidGain(5, 1.2, 0.1));
 
   //外れた時、黒線に乗るまで左に旋回
   int count = 0;


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- 第3ショートカットをライントレースに変更

## 実験方法
- 試走会で30回走らせる

## 実験データ
平均ゴールタイム:16.3858037(s)
ゴール率:90%(27/30)

## 実験結果
平均ゴールタイムは、[ticket-236](https://github.com/KatLab-MiyazakiUniv/etrobocon2021/pull/244)の15.899(s)よりも ***0.4868037(s)*** 増加し、 
ゴール率は ***80％→90%*** となる。
なお、現状の平均タイム、ゴール率とは比較していない
## 添付資料
[CSVファイルにまとめたもの](https://github.com/KatLab-MiyazakiUniv/etrobocon2021/files/7465149/time.ods)
[試走会のファイル置き場](https://drive.google.com/drive/folders/1Xi8NeBkOQZPgbUDV6MtKwW2mDWGGNQiM?usp=sharing)
[ランキング](https://ranking.etrobo.jp/)